### PR TITLE
Plano de melhoria (.ai) + tarefa 01: override specifiers

### DIFF
--- a/.ai/build-and-test.md
+++ b/.ai/build-and-test.md
@@ -1,0 +1,91 @@
+# Build & Testes — Ambiente Verificado
+
+Registro da verificação de que a suíte de testes do CEngine builda e roda neste
+ambiente. Serve como âncora para executar o [plano de melhoria](task/README.md)
+com segurança (rodar `ctest` a cada tarefa).
+
+- **Data da verificação:** 2026-07-04
+- **Plataforma:** Windows 11 Pro
+- **Resultado:** ✅ **30/30 testes passaram** (build limpo, sem warnings)
+
+## Toolchain confirmada
+
+| Ferramenta | Versão / Local |
+|-----------|----------------|
+| CMake | 4.0.2 (`C:\Program Files\CMake\bin\cmake.exe`) |
+| Compilador | g++ 15.1.0 — MSYS2 UCRT64 (`C:\msys64\ucrt64\bin\g++.exe`) |
+| Ninja | `C:\msys64\usr\bin\ninja.exe` |
+| GoogleTest | v1.17.0 (via FetchContent, já em cache) |
+
+> MSVC (`cl`) não está disponível no PATH neste ambiente; o build usa o preset
+> MinGW/MSYS2.
+
+## Como reproduzir
+
+O working directory precisa ser a raiz do projeto **cengine**. O preset
+`msys2-mingw` exige o MSYS2 no PATH (por causa do `g++`/`ninja`).
+
+```powershell
+# 1. Garantir o toolchain MSYS2 no PATH
+$env:PATH = "C:\msys64\ucrt64\bin;$env:PATH"
+
+# 2. Entrar no diretório do projeto
+Set-Location C:\Users\mrmar\Documents\projetos_de_estudo\c++\cengine
+
+# 3. Configurar (baixa GoogleTest na 1ª vez; precisa de rede)
+cmake --preset msys2-mingw
+
+# 4. Buildar a lib + o executável de testes
+cmake --build --preset msys2-mingw
+
+# 5. Rodar os testes
+Set-Location out/build/msys2-mingw
+ctest --output-on-failure
+```
+
+Alternativa (rodar o binário direto):
+
+```powershell
+out/build/msys2-mingw/src/test/cengine_tests.exe
+```
+
+## Saída obtida
+
+```
+-- Configuring done (1.5s)
+-- Generating done (0.1s)
+[100%] Built target cengine_tests
+...
+100% tests passed, 0 tests failed out of 30
+Total Test time (real) = 0.20 sec
+```
+
+## Cobertura da suíte (30 testes)
+
+- `SceneRepositoryTest` — registro/instanciação lazy via factory, unload,
+  clone de estado, comparação de estados.
+- `RouterInMemoryTest` — delegação do Router para o repositório.
+- `GameManagerTest` — ciclo `onEnter/render/input/onExit` e condição de saída.
+- `EngineManagerTest` + `EngineManagerIntegrationTest` — loop principal validado
+  por **call-log** (ordem exata das chamadas).
+
+## Observações ligadas ao plano de melhoria
+
+1. **O preset só funcionou por sorte de ambiente.** `CMakePresets.json` tem
+   caminhos absolutos hardcoded (`C:/msys64/ucrt64/...`) que batem com esta
+   máquina; numa máquina limpa falharia. → **[Tarefa 08](task/08-presets-and-ci.md)**.
+
+2. **Rede de segurança sólida.** Os 30 testes (incl. integração por call-log)
+   dão confiança para a cirurgia do `IRouter`. → **[Tarefa 05](task/05-redesign-irouter.md)**.
+
+3. **Os nomes dos próprios testes carregam os bugs de nomenclatura:**
+   - `GameManagerTest.ShouldExist_WhenStateIsNotExit_ReturnsFalse`
+   - `SceneRepositoryTest.IsNextStateEqualsToCurrentSceneReturnsTrueIfCodesDifferent`
+     (nome diz "Equals" mas retorna true quando os códigos **diferem**)
+
+   Ambos serão renomeados junto do código na **[Tarefa 02](task/02-fix-inverted-names.md)**.
+
+## Protocolo para as tarefas do plano
+
+A cada tarefa concluída: rebuildar e rodar `ctest`. Nenhuma tarefa é considerada
+`done` com a suíte quebrada (ver critérios de aceite em cada arquivo de tarefa).

--- a/.ai/decisions/0001-modular-core-vs-modules.md
+++ b/.ai/decisions/0001-modular-core-vs-modules.md
@@ -1,0 +1,135 @@
+# ADR 0001 — Core mínimo (loop) + módulos opcionais no mesmo repo
+
+- **Status:** Aceito
+- **Data:** 2026-07-04
+- **Contexto de decisão:** definição de escopo do CEngine e de onde vivem
+  responsabilidades como roteamento de telas e física.
+
+## Contexto
+
+O CEngine nasceu como projeto de estudo com uma mentalidade específica:
+
+> Uma engine que **não escolhe uma biblioteca gráfica**. O CEngine resolve o
+> **game loop** e entrega um **framework** para os jogos. No projeto do jogo ficam
+> as **regras de negócio**, a **construção das telas** e o **gráfico em si**. O
+> **motor do loop** fica no CEngine.
+
+O código atual, porém, embute no core uma máquina opinativa de **roteamento de
+telas / estados**: `GameManager` (concreto), `IRouter` + `RouterInMemory`,
+`ISceneRepository` + `SceneRepository`, `IState`. Isso faz o core ser mais que "o
+loop" — ele já decide *como* navegar entre telas. Essa camada foi identificada
+como a maior fonte de dívida arquitetural da engine.
+
+Surgiu então a pergunta: onde colocar roteamento (e, no futuro, física)?
+Repositório separado? Um módulo opcional `cengine::routing`? Dentro do core?
+
+## Decisão
+
+**Separar duas questões que estavam misturadas:**
+
+1. **Direção de dependência (o que importa):**
+   > O core (loop + portas) não depende de ninguém. Módulos (routing, physics)
+   > dependem do core. O jogo escolhe quais módulos linkar.
+
+2. **Empacotamento (logística):** **monorepo com múltiplos targets CMake**
+   (monolito modular). **Não** criar repositórios separados agora.
+
+### Fronteira de responsabilidades
+
+```
+┌────────────────── cengine::core (framework / loop) ──────────────────┐
+│  EngineManager    → dono do game loop (o "motor")                     │
+│  IWindowManager   → porta de plataforma/janela                        │
+│  IGameManager     → porta "o que fazer a cada frame"                  │
+│  IScene           → porta onEnter/input/render/onExit                 │
+│  (core não depende de nenhum módulo)                                  │
+└───────────────────────────────────────────────────────────────────────┘
+        ▲                              ▲
+ cengine::routing              cengine::physics        (targets opcionais)
+ (Router, SceneRepository,     (a definir)
+  IState, máquina de estados)
+        ▲                              ▲
+        └──────────────┬───────────────┘
+             projeto do jogo (ex.: 8Puzzle)
+   regras de negócio + telas + gráfico + escolhe o que linkar
+```
+
+### Layout de repositório alvo
+
+```
+cengine/
+├── core/                    → cengine::core
+│   └── include/cengine/core/…
+├── modules/
+│   ├── routing/             → cengine::routing  (PUBLIC dep: cengine::core)
+│   │   └── include/cengine/routing/…
+│   └── physics/             → cengine::physics  (futuro)
+├── tests/
+└── CMakeLists.txt
+```
+
+### Como o jogo escolhe (opt-in por target)
+
+```cmake
+FetchContent_MakeAvailable(cengine)
+
+target_link_libraries(8Puzzle PRIVATE
+    cengine::core        # sempre
+    cengine::routing     # opt-in
+    # cengine::physics   # não linkado → não entra no binário
+)
+```
+
+Quem não quer o roteador não linka e implementa a própria navegação. O core
+continua utilizável sozinho.
+
+## Consequências
+
+### Positivas
+
+- Core enxuto e fiel à mentalidade "engine = loop + portas".
+- Módulos são opt-in; nenhum jogo é forçado a carregar o que não usa.
+- Fronteiras de target limpas tornam a extração futura para repo separado
+  quase gratuita (mover uma pasta).
+
+### Negativas / custos
+
+- **Breaking change** para consumidores: `IRouter`, `SceneRepository`, `IState`
+  saem do core (mudam de include path/namespace e viram target à parte). O
+  8Puzzle terá de linkar `cengine::routing`. Coordenar com bump de versão
+  (provável `0.1.0`) e com o ADR de namespace (tarefa 03).
+- Configuração CMake mais elaborada (múltiplos targets, gating opcional dos
+  módulos para não buildar o que não é linkado).
+
+## Critérios para revisitar (quando abrir repo separado)
+
+Extrair um módulo para repositório próprio **só** quando surgir um gatilho real:
+
+- Cadência de release independente do core;
+- **Dependência externa pesada** (ex.: física com Box2D/Jolt) que não se quer
+  forçar sobre todo consumidor do core — este é o gatilho mais provável;
+- Licença distinta por módulo;
+- Donos/times distintos.
+
+Nenhum se aplica hoje → monorepo, **projetado para ser extraível**.
+
+## Notas de implementação
+
+- **Física tem uma sutileza:** costuma exigir *fixed timestep* (separar
+  `update(dt)` de `render()`). Hoje o loop (`EngineManager::run()`) não tem
+  conceito de tempo/`dt`. Física pode, portanto, forçar o **core a evoluir o
+  contrato do loop** — diferente de roteamento, que não toca no core. Não
+  resolver agora, mas não fechar o design do loop de um jeito que impeça isso.
+- `IState` (máquina de estados) é considerado conceito de **roteamento**, não de
+  core — vai para `cengine::routing`.
+
+## Relacionado
+
+- Reformula a **[Tarefa 05](../task/05-redesign-irouter.md)**: de "redesenhar o
+  `IRouter`" para "extrair o roteamento do core para `cengine::routing`".
+- Impacta a **[Tarefa 03](../task/03-namespace.md)** (namespaces por camada:
+  `cengine::core`, `cengine::routing`).
+- Impacta a **[Tarefa 06](../task/06-scene-lifetime.md)** (ciclo de vida das
+  cenas migra junto do roteamento).
+- Impacta a **[Tarefa 07](../task/07-cpp-standard.md)** (contrato entre core e
+  consumidores/módulos).

--- a/.ai/task/01-add-override.md
+++ b/.ai/task/01-add-override.md
@@ -1,6 +1,6 @@
 # 01 — Adicionar `override` em todas as sobrescritas
 
-- **Status:** todo
+- **Status:** done ✅ (2026-07-04, branch `feature/ai-plan-task-01`)
 - **Prioridade:** 🔴 Alta
 - **Categoria:** Boas práticas / correção
 - **Depende de:** —
@@ -40,9 +40,17 @@ Toda função que sobrescreve um método virtual deve estar marcada com `overrid
 
 ## Critérios de aceite
 
-- [ ] `grep` por métodos herdados sem `override` retorna vazio.
-- [ ] Projeto compila em Debug e Release.
-- [ ] `ctest` continua 100% verde.
+- [x] `grep` por métodos herdados sem `override` retorna vazio.
+- [x] Projeto compila em Debug e Release.
+- [x] `ctest` continua 100% verde.
+
+## Resultado da execução
+
+- `RouterInMemory.hpp`: adicionado `override` aos 11 métodos herdados de `IRouter`.
+- `GameManager.hpp`: `cleanup()` agora é `override`.
+- `SceneRepository.hpp`: já estava 100% coberto (nenhuma mudança).
+- Build limpo (nenhum `override` gerou erro → **não havia** bug de assinatura
+  escondido). `ctest`: **30/30 verde**.
 
 ## Riscos
 

--- a/.ai/task/01-add-override.md
+++ b/.ai/task/01-add-override.md
@@ -1,0 +1,50 @@
+# 01 — Adicionar `override` em todas as sobrescritas
+
+- **Status:** todo
+- **Prioridade:** 🔴 Alta
+- **Categoria:** Boas práticas / correção
+- **Depende de:** —
+- **Bloqueia:** É a rede de segurança que protege as tarefas 02, 05 e 06.
+
+## Problema
+
+Várias classes concretas sobrescrevem métodos virtuais **sem** a palavra-chave
+`override`. Sem ela, um erro de assinatura (parâmetro, `const`, tipo de retorno)
+não vira erro de compilação — vira silenciosamente um método novo, e a chamada
+virtual continua indo para a versão abstrata/errada.
+
+Ocorrências conhecidas:
+
+- `src/main/engine/service/impl/RouterInMemory.hpp` — **nenhum** dos ~11 métodos
+  tem `override` (ex.: `void setNextState(std::unique_ptr<IState> state) const;`).
+- `src/main/engine/GameManager.hpp` — `void cleanup();` é override de
+  `IGameManager::cleanup()`, mas não está marcado.
+
+Faça uma varredura por todas as classes que herdam de uma interface
+(`RouterInMemory`, `SceneRepository`, `GameManager`, `EngineManager` não herda)
+e confirme que **toda** sobrescrita tem `override`.
+
+## Objetivo
+
+Toda função que sobrescreve um método virtual deve estar marcada com `override`
+(e destrutores virtuais com `override` quando aplicável).
+
+## Passos
+
+1. Em `RouterInMemory.hpp`, adicionar `override` a todos os métodos herdados de
+   `IRouter`.
+2. Em `GameManager.hpp`, marcar `cleanup()` como `override`.
+3. Revisar `SceneRepository.hpp` (já usa `override` na maioria — confirmar 100%).
+4. Compilar. **Se algum `override` gerar erro de compilação, ótimo:** achamos um
+   bug de assinatura escondido — corrigir a assinatura, não remover o `override`.
+
+## Critérios de aceite
+
+- [ ] `grep` por métodos herdados sem `override` retorna vazio.
+- [ ] Projeto compila em Debug e Release.
+- [ ] `ctest` continua 100% verde.
+
+## Riscos
+
+Baixíssimo. No pior caso, expõe um bug pré-existente de assinatura — o que é o
+resultado desejado.

--- a/.ai/task/02-fix-inverted-names.md
+++ b/.ai/task/02-fix-inverted-names.md
@@ -1,0 +1,67 @@
+# 02 — Corrigir nomes invertidos e semântica enganosa
+
+- **Status:** todo
+- **Prioridade:** 🔴 Alta
+- **Categoria:** Boas práticas / legibilidade
+- **Depende de:** 01 (rede de segurança de `override` já ativa)
+- **Bloqueia:** 05 (o redesenho do Router fica mais claro com nomes corretos)
+
+## Problema
+
+Dois nomes dizem o **oposto** do que o código faz — a maior fonte de confusão
+ao ler o loop principal.
+
+### 2.1 `shouldExist()` → `shouldExit()`
+
+```cpp
+// EngineManager.cpp
+m_isRunning = !m_gameManager->shouldExist();   // "não deve existir"? ilegível
+// GameManager.cpp
+bool GameManager::shouldExist() const { return ...getCode() == "exit"; }
+```
+
+O método retorna `true` quando o jogo deve **sair**. Nome correto: `shouldExit()`.
+
+Arquivos afetados: `include/engine/IGameManager.hpp`, `GameManager.hpp/.cpp`,
+`EngineManager.cpp`, e todos os mocks/fakes de teste
+(`MockGameManager.hpp`, `FakeImplementations.hpp`).
+
+### 2.2 `isNextStateEqualsToCurrentScene()` retorna `!=`
+
+```cpp
+bool SceneRepository::isNextStateEqualsToCurrentScene() const {
+    return m_nextState->getCode() != m_currentState->getCode();  // != num "isEquals"
+}
+```
+
+E `RouterInMemory::hasNextScreen()` delega a esse método. O comportamento final
+está correto (há próxima tela quando next ≠ current), mas o nome mente.
+
+**Decisão:** renomear para expressar a intenção real. Sugestão:
+`bool hasPendingStateChange() const` (ou `isNextStateDifferentFromCurrent()`),
+retornando `next != current` — assim nome e corpo concordam.
+
+## Objetivo
+
+Nome de cada método concorda com o valor booleano que ele retorna.
+
+## Passos
+
+1. Renomear `shouldExist` → `shouldExit` na interface, implementação, chamadas e
+   todos os dublês de teste. Ajustar o `!` em `EngineManager::run()`.
+2. Renomear `isNextStateEqualsToCurrentScene` → `hasPendingStateChange` (ou nome
+   equivalente) em `ISceneRepository`, `SceneRepository`, e no chamador em
+   `RouterInMemory::hasNextScreen()`.
+3. Rodar os testes; ajustar nomes nos `.cpp` de teste que referenciam esses
+   métodos.
+
+## Critérios de aceite
+
+- [ ] Nenhum método booleano com nome contrário ao retorno.
+- [ ] `EngineManager::run()` fica legível (`m_isRunning = !...shouldExit()`).
+- [ ] `ctest` 100% verde.
+
+## Riscos
+
+Baixo — é rename mecânico. Cuidar de atualizar mocks/fakes junto para não quebrar
+a compilação dos testes.

--- a/.ai/task/03-namespace.md
+++ b/.ai/task/03-namespace.md
@@ -1,0 +1,49 @@
+# 03 — Introduzir namespaces por camada
+
+- **Status:** absorvida pela [05a](05a-restructure-modules.md)
+- **Prioridade:** 🟡 Média
+- **Categoria:** Arquitetura / distribuição
+- **Depende de:** 01
+- **Nota:** esta tarefa **deixou de ser executada isoladamente**. O namespace por
+  camada (`cengine::core` / `cengine::routing`) nasce junto da reorganização em
+  módulos — ver [05a](05a-restructure-modules.md) e [ADR 0001](../decisions/0001-modular-core-vs-modules.md).
+  Este arquivo permanece como referência técnica do que precisa ser namespaceado.
+
+## Problema
+
+Todo o código está no **namespace global**: `EngineManager`, `IState`,
+`GameManager`, `IRouter`, etc. Como a engine é **consumida via FetchContent**
+(o projeto 8Puzzle faz exatamente isso), esses nomes poluem o escopo global do
+consumidor e podem colidir com símbolos dele.
+
+## Objetivo
+
+Toda a API pública e implementação interna dentro de `namespace cengine { ... }`.
+
+## Passos
+
+1. Envolver os headers públicos (`include/engine/*.hpp`) em `namespace cengine`.
+2. Envolver a implementação interna (`src/main/engine/**`) no mesmo namespace.
+3. Atualizar testes, mocks e fakes para qualificar (`cengine::EngineManager`) ou
+   usar `using namespace cengine;` no escopo de teste.
+4. **Namespaces por camada, alinhados ao [ADR 0001](../decisions/0001-modular-core-vs-modules.md):**
+   o core em `cengine::core` e o roteamento (quando extraído na tarefa 05) em
+   `cengine::routing`. Isso prepara o terreno para a separação em módulos — sem
+   overengineering, mas já com a fronteira desenhada nos namespaces.
+
+## Critérios de aceite
+
+- [ ] Nenhum símbolo público da engine no namespace global.
+- [ ] Testes compilam e passam com os nomes qualificados.
+- [ ] Um consumidor (ex.: 8Puzzle) precisaria escrever `cengine::EngineManager`.
+
+## Riscos
+
+Médio em *volume* de mudança (toca muitos arquivos), baixo em *complexidade*.
+É uma boa tarefa para fazer isolada, num commit só, antes da refatoração 05.
+
+## Nota de compatibilidade
+
+Isso é uma **quebra de API** para consumidores existentes (o 8Puzzle terá de
+qualificar os nomes). Coordenar com a tarefa 07 e com o versionamento
+(provável bump para `0.1.0`).

--- a/.ai/task/04-const-and-logging.md
+++ b/.ai/task/04-const-and-logging.md
@@ -1,0 +1,67 @@
+# 04 — `const`-correctness + remover logging da biblioteca
+
+- **Status:** todo
+- **Prioridade:** 🟡 Média
+- **Categoria:** Boas práticas
+- **Depende de:** 01, 02
+- **Bloqueia:** 05 (o Router será redesenhado; melhor entrar nele já com a
+  semântica de `const` correta)
+
+## Problema
+
+### 4.1 `const` que mente
+
+`RouterInMemory` marca como `const` métodos que **mutam estado** (através do
+`shared_ptr` membro, o que escapa da verificação do compilador):
+
+```cpp
+void RouterInMemory::setNextState(std::unique_ptr<IState> state) const {
+    m_sceneRepository->persistNextState(std::move(state));   // muta!
+}
+void RouterInMemory::goToNextScreen() const {
+    m_sceneRepository->unloadScene(...);                     // muta!
+    m_sceneRepository->persisteCurrentState();               // muta!
+}
+```
+
+Métodos que alteram o estado observável do objeto **não devem** ser `const`.
+Isso engana o leitor e impede raciocínio sobre thread-safety.
+
+### 4.2 Biblioteca escrevendo em `std::cout`
+
+```cpp
+void GameManager::cleanup() {
+    std::cout << "TerminalGameManager: cleanup" << std::endl;  // lib não deve logar
+}
+```
+
+Uma engine não deve escrever direto no stdout do consumidor. Além disso,
+`std::endl` força flush desnecessário.
+
+## Objetivo
+
+- `const` reflete fielmente se o método muta ou não o objeto.
+- A biblioteca não faz I/O de log direto; ou remove, ou injeta uma abstração.
+
+## Passos
+
+1. Remover `const` de `setNextState`, `goToNextScreen` (e de qualquer outro
+   mutador marcado indevidamente) em `IRouter` e `RouterInMemory`.
+   > Atenção: mexer na assinatura na interface exige atualizar mocks (`MockRouter`).
+2. Remover o `std::cout` de `GameManager::cleanup()`. Opções:
+   - **Mínimo:** simplesmente remover o log.
+   - **Recomendado (leve):** definir uma interface `ILogger` injetável e trocar
+     `std::cout` por `m_logger->info(...)`. Se for adiar, deixar TODO e apenas
+     remover o `cout` por ora.
+3. Remover `#include <iostream>` que ficar órfão (ver tarefa 09).
+
+## Critérios de aceite
+
+- [ ] Nenhum mutador marcado como `const`.
+- [ ] Nenhum `std::cout`/`std::endl` no código de produção da lib.
+- [ ] Testes verdes.
+
+## Riscos
+
+Baixo. A mudança de `const` na interface pode exigir ajuste nos mocks — fazer
+junto para não quebrar a build de teste.

--- a/.ai/task/05a-restructure-modules.md
+++ b/.ai/task/05a-restructure-modules.md
@@ -1,0 +1,71 @@
+# 05a — Reorganização estrutural: `cengine::core` + `cengine::routing`
+
+- **Status:** todo
+- **Prioridade:** 🔴 Alta (arquitetural)
+- **Categoria:** Arquitetura / build
+- **Depende de:** 01 (rede de segurança de `override` ativa)
+- **Absorve:** [Tarefa 03](03-namespace.md) (namespaces por camada nascem aqui)
+- **Bloqueia:** 05b, 06
+- **Decisão de referência:** [ADR 0001](../decisions/0001-modular-core-vs-modules.md)
+
+> **Move puro, sem mudança de comportamento.** Esta tarefa move arquivos e
+> reconfigura o CMake para o layout modular do ADR 0001. **Nenhuma lógica muda.**
+> O critério de aceite é brutal: `ctest` continua **30/30 idêntico**. O redesenho
+> do roteador (enxugar `IRouter`, Scene/Screen, desacoplar) fica para a 05b.
+
+## Objetivo
+
+Sair de uma única lib (`cengine_lib`) para o layout modular:
+
+```
+cengine/
+├── core/                    → cengine::core   (namespace cengine::core)
+│   └── include/cengine/core/…   EngineManager, IWindowManager, IGameManager, IScene
+├── modules/
+│   └── routing/             → cengine::routing (namespace cengine::routing)
+│       └── include/cengine/routing/…  IRouter, RouterInMemory, ISceneRepository,
+│                                       SceneRepository, IState, GameManager
+├── tests/
+└── CMakeLists.txt
+```
+
+## Passos
+
+1. **Definir a fronteira do core.** Fica no core: `EngineManager`,
+   `IWindowManager`, `IGameManager`, `IScene`. Vai para routing: `IRouter`,
+   `RouterInMemory`, `ISceneRepository`, `SceneRepository`, `IState` e o
+   `GameManager` (router-based).
+2. **Mover os arquivos** para `core/` e `modules/routing/` conforme o layout.
+   Ajustar todos os `#include` (fim dos caminhos relativos monstruosos — casa com
+   a tarefa 09, mas aqui é consequência natural do move).
+3. **Aplicar namespaces por camada** (absorve a tarefa 03): `cengine::core::*` e
+   `cengine::routing::*`. Atualizar testes/mocks para qualificar os nomes.
+4. **CMake multi-target:**
+   - `add_library(cengine_core …)` expondo `core/include` como `PUBLIC`;
+     alias `cengine::core`.
+   - `add_library(cengine_routing …)` com
+     `target_link_libraries(cengine_routing PUBLIC cengine::core)`;
+     alias `cengine::routing`.
+   - **Gating opcional** do módulo routing (ex.: `option(CENGINE_BUILD_ROUTING …)`)
+     para não buildar quando o consumidor não linka.
+5. **Reorganizar os testes** por camada: testes do loop (`EngineManager`) sob o
+   core; testes de router/cenas/estado sob routing. Manter os dois na suíte
+   `ctest`.
+6. **Não redesenhar nada.** Se bater vontade de "já que estou aqui, arrumo o
+   IRouter" — resistir. Isso é a 05b.
+
+## Critérios de aceite
+
+- [ ] `cengine::core` e `cengine::routing` existem como targets separados, com
+      `routing` dependendo `PUBLIC` do `core`.
+- [ ] Namespaces `cengine::core` / `cengine::routing` aplicados.
+- [ ] `ctest` continua **30/30**, comportamento idêntico (é move, não redesign).
+- [ ] Um consumidor consegue linkar só `cengine::core` e buildar o loop sem routing.
+
+## Riscos
+
+Médio — concentrado no CMake (multi-target + gating), não na lógica. **É breaking
+para o 8Puzzle:** `cengine_lib` deixa de existir; o consumidor passará a linkar
+`cengine::core` (+ `cengine::routing` se quiser). Coordenar com bump `0.1.0`.
+Atualizar o 8Puzzle é parte da 05b (quando o desenho final estabilizar) ou um
+passo imediato aqui, se preferir mantê-lo compilando.

--- a/.ai/task/05b-redesign-irouter.md
+++ b/.ai/task/05b-redesign-irouter.md
@@ -1,0 +1,76 @@
+# 05b — Redesenhar o `IRouter` (dentro de `cengine::routing`)
+
+- **Status:** todo
+- **Prioridade:** 🔴 Alta (arquitetural)
+- **Categoria:** Arquitetura
+- **Depende de:** 05a (estrutura modular já pronta)
+- **Bloqueia:** 06
+- **Decisão de referência:** [ADR 0001](../decisions/0001-modular-core-vs-modules.md)
+
+> A 05a já **moveu** o roteamento para `cengine::routing` sem mudar comportamento.
+> Esta tarefa faz a **limpeza de design** do roteador — agora isolada no módulo,
+> sem risco de contaminar o core.
+
+## Problemas de desenho a corrigir
+
+Arquivo (após a 05a): `modules/routing/…/IRouter.hpp`
+
+1. **Interface gorda (viola ISP).** ~12 métodos, com 6 pares quase idênticos
+   `getCurrent* / getNext*`. Os `...Name` e `...Code` são só delegação para
+   `IState::getName()/getCode()` — não precisam estar na interface do Router.
+
+2. **Acoplamento entre portas.** `IRouter.hpp` inclui
+   `repository/ISceneRepository.hpp`. Resolver com forward declaration + injeção.
+
+3. **Vocabulário Scene vs Screen.** Unificar em **Scene** (alinha com
+   `IScene`/`SceneRepository`), eliminando "Screen"
+   (`getCurrentCachedScreen`→`currentScene`, `hasNextScreen`, `goToNextScreen`).
+
+## Direção de design proposta (revisar antes de codar)
+
+```cpp
+namespace cengine::routing {
+class IRouter {
+public:
+    virtual ~IRouter() = default;
+
+    void requestState(std::unique_ptr<IState> next);          // ex-setNextState
+    [[nodiscard]] bool hasPendingStateChange() const;         // ex-hasNextScreen
+    void commitStateChange();                                 // ex-goToNextScreen
+
+    [[nodiscard]] IState& currentState() const;
+    [[nodiscard]] IScene& currentScene() const;
+};
+}
+```
+
+- `...Name`/`...Code` saem: quem precisar chama `currentState().getName()/getCode()`.
+- `getNext*` só permanece se houver caso de uso real de espiar a próxima cena
+  antes do commit; senão, remover (YAGNI).
+- Confirmar o conjunto mínimo consultando **todos** os chamadores reais
+  (hoje: `GameManager`).
+
+## Passos
+
+1. Levantar (grep) os chamadores reais de cada método de `IRouter`.
+2. Validar o desenho enxuto acima.
+3. Reescrever `RouterInMemory`; mover as delegações `...Name/...Code` para os
+   chamadores.
+4. Remover o include de `ISceneRepository.hpp` do header de `IRouter`.
+5. Renomear Screen → Scene em toda a cadeia (Router, GameManager, testes).
+6. Atualizar `MockRouter` e os testes.
+7. Atualizar o consumidor de referência (8Puzzle) para a nova API + link
+   `cengine::routing`.
+
+## Critérios de aceite
+
+- [ ] `IRouter` com no máximo ~5–6 métodos coesos.
+- [ ] `IRouter.hpp` não inclui `ISceneRepository.hpp`.
+- [ ] Vocabulário único (Scene).
+- [ ] Testes de integração do loop passam **sem mudança de comportamento**.
+
+## Riscos
+
+Médio/Alto — mexe em interface pública do módulo. Mitigadores: 01–04 estabilizaram
+o terreno, 05a isolou o roteamento, e o `EngineManagerIntegrationTest` trava
+regressão de comportamento por call-log.

--- a/.ai/task/06-scene-lifetime.md
+++ b/.ai/task/06-scene-lifetime.md
@@ -1,0 +1,72 @@
+# 06 — Corrigir ciclo de vida / referências de cena (risco de dangling)
+
+- **Status:** todo
+- **Prioridade:** 🟡 Média
+- **Categoria:** Arquitetura / correção
+- **Depende de:** 05a (estrutura modular) e 05b (desenho final do Router/Repository)
+- **Decisão de referência:** [ADR 0001](../decisions/0001-modular-core-vs-modules.md) —
+  esta correção acontece **dentro do módulo `cengine::routing`**, não no core.
+
+## Problema
+
+`getCurrentCachedScreen()` (e correlatos) retornam `IScene&` — uma referência
+para dentro do `std::unordered_map` do `SceneRepository`:
+
+```cpp
+IScene& SceneRepository::getScene(const std::string& name) {
+    ...
+    return *(m_scenes[name]);   // referência para o unique_ptr dentro do mapa
+}
+```
+
+Em `GameManager::onExit()`, a sequência é:
+
+```cpp
+IScene& screen = m_routerService->getCurrentCachedScreen();
+screen.onExit();
+m_routerService->goToNextScreen();   // -> unloadScene(current) -> m_scenes.erase(...)
+```
+
+Hoje **funciona** porque a referência é usada *antes* do `erase`. Mas é frágil:
+qualquer refatoração que segure essa referência após uma navegação/unload causa
+**use-after-free**. `unordered_map::erase` invalida referências ao elemento
+removido.
+
+## Objetivo
+
+Eliminar a janela de dangling: nenhuma referência a cena sobrevive a uma operação
+que possa descarregá-la.
+
+## Opções de design (decidir na tarefa)
+
+1. **Escopo estreito (mínimo):** documentar o contrato "a referência é válida
+   apenas até a próxima navegação" e garantir por código que nenhum caller a
+   retém. Barato, mas continua frágil.
+2. **Handle/indireção:** o repositório retorna um handle estável (ex.: índice ou
+   `weak`/observador) em vez de referência crua ao conteúdo do mapa.
+3. **`shared_ptr<IScene>` (recomendado avaliar):** o mapa guarda
+   `shared_ptr<IScene>` e os getters retornam `shared_ptr`. Um `unloadScene`
+   remove do mapa, mas quem ainda segura o `shared_ptr` mantém a cena viva até
+   soltar — elimina o use-after-free de forma robusta.
+
+> Ponderar custo x benefício: (3) é o mais seguro, mas muda assinaturas públicas
+> (coordenar com 05). (1) é aceitável para um projeto de estudo se bem documentado.
+
+## Passos
+
+1. Mapear todos os pontos que obtêm referência de cena e o que fazem depois.
+2. Escolher a estratégia (recomendação: shared_ptr no repositório de cenas).
+3. Implementar e ajustar `getScene`/`getCurrent...`/`GameManager`.
+4. Adicionar um teste que exercite: obter cena → navegar/unload → garantir que
+   não há acesso inválido (rodar sob ASan idealmente — ver tarefa 08).
+
+## Critérios de aceite
+
+- [ ] Nenhum caminho retém referência a cena através de um `unloadScene`.
+- [ ] Teste cobrindo o cenário de navegação + unload.
+- [ ] (Se ASan disponível) suíte passa limpa sob AddressSanitizer.
+
+## Riscos
+
+Médio. Mudança de assinatura se optar por `shared_ptr`. Fazer logo após 05 para
+não retrabalhar a interface do Router duas vezes.

--- a/.ai/task/07-cpp-standard.md
+++ b/.ai/task/07-cpp-standard.md
@@ -1,0 +1,55 @@
+# 07 — Alinhar padrão C++ entre cengine e consumidores
+
+- **Status:** todo
+- **Prioridade:** 🟡 Média
+- **Categoria:** Ecossistema / compatibilidade
+- **Depende de:** — (independente do código; coordenar com 03, que já é breaking)
+
+## Problema
+
+- **cengine** compila em **C++23** (`set(CMAKE_CXX_STANDARD 23)` +
+  `CXX_STANDARD 23` no target).
+- O consumidor **8Puzzle** usa **C++20** (`set(CMAKE_CXX_STANDARD 20)`), e puxa a
+  engine via `FetchContent` na tag `0.0.1`.
+
+Hoje os headers públicos **não usam** features de C++23, então "passa". Mas é uma
+bomba-relógio: no dia em que um header público (`include/engine/*`) usar algo de
+C++23, o build do 8Puzzle quebra — porque o header é compilado no padrão do
+consumidor, não no da lib.
+
+## Objetivo
+
+Definir e documentar um contrato de padrão C++ claro entre a lib e seus
+consumidores, evitando incompatibilidade silenciosa.
+
+## Opções
+
+1. **Rebaixar a lib para C++20** — máxima compatibilidade com o 8Puzzle atual.
+2. **Subir o 8Puzzle para C++23** — se você quer usar features novas na engine.
+3. **Manter C++23 na lib, mas garantir headers públicos ≤ C++20** e propagar o
+   requisito via `target_compile_features(cengine_lib PUBLIC cxx_std_23)` para
+   que o CMake force o padrão nos consumidores (em vez de só uma propriedade
+   local do target).
+
+> Recomendação: decidir o padrão-alvo do ecossistema e usar
+> `target_compile_features(... PUBLIC ...)` para que o requisito **propague**
+> automaticamente a quem linkar `cengine_lib`, em vez de depender de cada
+> consumidor configurar o padrão certo na mão.
+
+## Passos
+
+1. Decidir o padrão-alvo (recomendo alinhar ambos e usar `PUBLIC` compile
+   features).
+2. Ajustar `CMakeLists.txt` do cengine para propagar o requisito.
+3. Validar buildando o 8Puzzle contra a nova tag da engine.
+4. Documentar no README o padrão mínimo exigido.
+
+## Critérios de aceite
+
+- [ ] Padrão C++ propagado via `target_compile_features(... PUBLIC ...)`.
+- [ ] 8Puzzle builda contra a engine sem configurar padrão manualmente.
+- [ ] README documenta o requisito.
+
+## Riscos
+
+Baixo. Envolve decisão de produto (quais features usar) mais que técnica.

--- a/.ai/task/08-presets-and-ci.md
+++ b/.ai/task/08-presets-and-ci.md
@@ -1,0 +1,53 @@
+# 08 — Presets portáveis + CI (Debug + sanitizers)
+
+- **Status:** todo
+- **Prioridade:** 🟢 Baixa
+- **Categoria:** Ecossistema / build
+- **Depende de:** — (independente; porém ASan ajuda a validar a tarefa 06)
+
+## Problema
+
+### 8.1 `CMakePresets.json` não é portável
+
+O único preset (`msys2-mingw`) tem **caminhos absolutos hardcoded** da sua
+máquina:
+
+```json
+"CMAKE_CXX_COMPILER": "C:/msys64/ucrt64/bin/g++.exe",
+"CMAKE_MAKE_PROGRAM": "C:/msys64/ucrt64/bin/mingw32-make.exe"
+```
+
+Ninguém além de você consegue usar. E o CI nem usa presets — roda `cmake` puro.
+(Compare com o 8Puzzle, que tem presets genéricos `x64-debug`/`x64-release`.)
+
+### 8.2 CI não cobre Debug nem sanitizers
+
+O workflow builda Release no Windows e default no Linux, sem AddressSanitizer /
+UBSanitizer. Para uma engine cheia de ponteiros e referências (ver tarefa 06),
+ASan/UBSan é a ferramenta que pega dangling/use-after-free automaticamente.
+
+## Objetivo
+
+Presets utilizáveis por qualquer pessoa e um CI que exercite Debug + sanitizers.
+
+## Passos
+
+1. Adicionar presets genéricos que não dependam de caminhos absolutos
+   (ex.: `debug`, `release`, deixando o CMake detectar o compilador; manter o
+   `msys2-mingw` como preset local opcional, talvez em `CMakeUserPresets.json`
+   que fica fora do versionamento).
+2. Adicionar um preset/flags de sanitizers para builds Debug
+   (`-fsanitize=address,undefined` em GCC/Clang).
+3. Atualizar o CI:
+   - Adicionar job Debug no Linux com ASan/UBSan rodando `ctest`.
+   - Opcional: usar os presets no CI para evitar duplicar configuração.
+
+## Critérios de aceite
+
+- [ ] `cmake --preset debug` funciona numa máquina limpa (sem paths hardcoded).
+- [ ] CI tem um job Debug com ASan/UBSan verde.
+- [ ] Preset específico de máquina (msys2) não atrapalha outros devs.
+
+## Riscos
+
+Baixo. Pode revelar bugs de memória latentes ao ligar ASan — o que é o objetivo.

--- a/.ai/task/09-code-hygiene.md
+++ b/.ai/task/09-code-hygiene.md
@@ -1,0 +1,58 @@
+# 09 — Higiene de código (includes, código morto, forward-declares)
+
+- **Status:** todo
+- **Prioridade:** 🟢 Baixa
+- **Categoria:** Boas práticas / limpeza
+- **Depende de:** 05 (fazer a limpeza depois da refatoração grande, para não
+  limpar código que vai ser reescrito)
+
+## Problemas (agrupados — limpeza de baixo risco)
+
+1. **Include com caminho relativo frágil.**
+   `src/main/engine/service/repository/SceneRepository.hpp`:
+   ```cpp
+   #include "../../../../../include/engine/IScene.hpp"
+   ```
+   Cinco níveis de `../`. Trocar por `<engine/IScene.hpp>` (já está no include
+   path público).
+
+2. **Código morto / não utilizado.**
+   - `EngineManager::input()` é `public` mas ninguém chama (o loop usa
+     `m_gameManager->input()` direto). Remover ou justificar.
+   - `#include <iostream>` órfão em `EngineManager.cpp` (nenhum uso).
+     > Nota: o `iostream` de `GameManager.cpp` sai na tarefa 04.
+
+3. **Linhas comentadas (dead comments).**
+   - `include/engine/IScene.hpp` linhas 4, 10-11.
+   - `GameManager.cpp` (comentário `// std::println("")`).
+   Remover — o histórico do git guarda, não precisa ficar no código.
+
+4. **Forward-declares redundantes.**
+   `IRouter.hpp` faz `#include <engine/IState.hpp>` **e** `class IState;` na mesma
+   unidade. Escolher um: se usa o tipo completo, mantém o include e tira o
+   forward; se só usa referência/ponteiro, prefere forward e tira o include.
+   Revisar também `RouterInMemory.hpp` e `ISceneRepository.hpp`.
+
+## Objetivo
+
+Base de código sem includes frágeis, sem símbolos mortos e sem ruído de
+comentários obsoletos.
+
+## Passos
+
+1. Trocar o include relativo por `<engine/IScene.hpp>`.
+2. Remover `EngineManager::input()` (após confirmar que nada externo usa).
+3. Remover includes órfãos (`<iostream>`).
+4. Apagar linhas comentadas obsoletas.
+5. Racionalizar forward-declares vs includes.
+6. (Opcional) rodar `include-what-you-use` ou `clang-tidy` para varredura ampla.
+
+## Critérios de aceite
+
+- [ ] Sem caminhos `../../../` em includes.
+- [ ] Sem métodos públicos sem uso / includes órfãos.
+- [ ] Testes verdes.
+
+## Riscos
+
+Baixo. Prestar atenção só para não remover algo que a tarefa 05 passou a usar.

--- a/.ai/task/10-typed-states.md
+++ b/.ai/task/10-typed-states.md
@@ -1,0 +1,61 @@
+# 10 — Eliminar magic string e estados *stringly-typed*
+
+- **Status:** todo
+- **Prioridade:** 🟢 Baixa
+- **Categoria:** Boas práticas / design
+- **Depende de:** 02 (nomes já corrigidos), 05 (desenho do Router estável)
+
+## Problema
+
+### 10.1 Magic string `"exit"`
+
+```cpp
+bool GameManager::shouldExit() const {   // (após tarefa 02)
+    return m_routerService->getCurrentStateGameCode() == "exit";
+}
+```
+
+O código de saída `"exit"` é uma string mágica embutida na lógica de controle do
+loop. Se o consumidor escrever `"Exit"` ou `"quit"`, o jogo nunca sai, sem erro
+de compilação.
+
+### 10.2 Estados identificados por `std::string`
+
+`IState` expõe `getCode()`/`getName()` como `std::string`. Comparar estados por
+string é frágil (typos silenciosos), mais lento e sem checagem em tempo de
+compilação.
+
+## Objetivo
+
+Tornar a identificação de estados robusta a erros de digitação e explícita.
+
+## Opções (decidir na tarefa)
+
+1. **Mínimo:** extrair `"exit"` para uma constante nomeada
+   (`constexpr std::string_view kExitStateCode = "exit";`) em um header central.
+   Resolve o magic string sem redesenhar `IState`.
+2. **Intermediário:** o consumidor sinaliza saída por um mecanismo tipado — ex.:
+   o Router/GameManager expõe `requestExit()` e o loop consulta um `bool`, em vez
+   de comparar código de estado por string.
+3. **Amplo:** repensar `IState` para identificação por `enum class` ou tipo forte
+   em vez de `std::string` livre. Maior impacto na API — avaliar se compensa para
+   um projeto de estudo.
+
+> Recomendação: começar pela opção 1 (barata) e avaliar a 2 como evolução natural
+> do desenho do Router (tarefa 05). A opção 3 só se houver dor real com strings.
+
+## Passos
+
+1. Extrair `"exit"` para constante nomeada e usar em todos os pontos.
+2. (Se optar por 2) expor sinal de saída tipado no Router/GameManager.
+3. Atualizar testes que dependem do código `"exit"`.
+
+## Critérios de aceite
+
+- [ ] Nenhuma string literal de código de estado espalhada na lógica.
+- [ ] Um typo em código de estado é detectável (constante única / tipo forte).
+- [ ] Testes verdes.
+
+## Riscos
+
+Baixo na opção 1; médio se mexer em `IState` (opção 3) — coordenar com 05.

--- a/.ai/task/11-documentation.md
+++ b/.ai/task/11-documentation.md
@@ -1,0 +1,55 @@
+# 11 — Documentação (Doxygen nos headers + uso no README)
+
+- **Status:** todo
+- **Prioridade:** 🟢 Baixa
+- **Categoria:** Documentação
+- **Depende de:** todas as anteriores (documentar a API **já estabilizada**, para
+  não escrever doc de código que vai mudar)
+
+## Problema
+
+A documentação atual cobre "como buildar/testar", mas quase nada do "o que a API
+faz e como usá-la":
+
+- Os headers públicos (`include/engine/*.hpp`) **não têm comentários de API**
+  (nem Doxygen). O contrato do ciclo de vida das cenas
+  (`onEnter → draw/input → onExit`) e a ordem esperada de chamadas não estão
+  documentados em lugar nenhum.
+- O `README.md` da raiz descreve a filosofia do projeto, mas **não mostra um
+  exemplo de uso** — nem que o consumo é via `FetchContent` (o 8Puzzle faz isso).
+- Não existe pasta `documentation/` (o 8Puzzle tem uma; inconsistência entre os
+  dois projetos).
+
+## Objetivo
+
+Um consumidor (inclusive "você do futuro") consegue entender e usar a engine só
+pela documentação, sem ler a implementação.
+
+## Passos
+
+1. **Doc-comments (Doxygen) nos headers públicos** de `include/engine/`:
+   - Contrato e ordem do ciclo de vida em `IScene`
+     (`onEnter`/`onEnterExecuted`/`isOnEnterExecuted`/`draw`/`input`/`onExit`).
+   - Semântica de `IGameManager` (incluindo `shouldExit`, já renomeado na
+     tarefa 02).
+   - `IWindowManager`, `IState` (incluindo o porquê do `clone()` — prototype),
+     e a `IRouter` já enxuta (tarefa 05).
+2. **Seção "Uso" no README** com exemplo mínimo:
+   - como declarar a dependência via `FetchContent` (espelhando o 8Puzzle);
+   - montar `EngineManager` com um `WindowManager` e um `GameManager`;
+   - registrar cenas via factory e navegar por estados.
+3. (Opcional) criar `documentation/` com um diagrama das camadas
+   (EngineManager → GameManager → Router → SceneRepository → Scene/State),
+   alinhando com o padrão do 8Puzzle.
+4. (Opcional) configurar geração Doxygen no CMake/CI.
+
+## Critérios de aceite
+
+- [ ] Todos os headers públicos com doc-comment explicando contrato.
+- [ ] README com exemplo de consumo via FetchContent e montagem da engine.
+- [ ] Nenhum código comentado remanescente (coordenar com tarefa 09).
+
+## Riscos
+
+Nenhum funcional. O cuidado é **cronológico**: documentar por último, quando a
+API (especialmente o Router) já estiver estável, para não retrabalhar a doc.

--- a/.ai/task/README.md
+++ b/.ai/task/README.md
@@ -1,0 +1,64 @@
+# Plano de Melhoria — CEngine
+
+Este diretório contém o plano de melhoria da engine, derivado de uma avaliação
+técnica (arquitetura + boas práticas). Cada arquivo é uma tarefa independente,
+numerada na **ordem de desenvolvimento recomendada**.
+
+## Princípio da ordenação
+
+A mudança de maior impacto é **tirar o roteamento do core** e reorganizar em
+módulos (`cengine::core` + `cengine::routing`, ver [ADR 0001](../decisions/0001-modular-core-vs-modules.md)).
+Como é grande e *breaking*, ela é feita cedo — porém **precedida de uma rede de
+segurança barata** e **separando "mover" de "redesenhar"**.
+
+**Ordem de execução recomendada** (não é estritamente a ordem numérica):
+
+1. **Rede de segurança (01):** adicionar `override` — trivial e endurece o
+   compilador **antes** da grande movimentação de código.
+2. **Reorganização estrutural (05a):** mover para `core/` + `modules/routing/`,
+   CMake multi-target, namespaces por camada. **Move puro, sem mudar
+   comportamento** (absorve a antiga tarefa 03 de namespace).
+3. **Redesenho do roteador (05b):** enxugar o `IRouter`, unificar Scene/Screen,
+   desacoplar — já isolado dentro de `cengine::routing`.
+4. **Correções de qualidade (02, 04, 06):** nomes invertidos, `const`/logging e
+   ciclo de vida das cenas — agora no lugar final.
+5. **Ecossistema/build (07–08):** padrão C++, presets, CI.
+6. **Limpeza final e documentação (09–11).**
+
+> Regra prática: manter a suíte de testes **verde a cada tarefa**. Nenhuma
+> tarefa deve ser mergeada com testes quebrados.
+>
+> **Nota sobre a tarefa 03:** o namespace deixou de ser tarefa isolada — ele
+> nasce junto da reorganização em módulos (05a), como `cengine::core` /
+> `cengine::routing`. O arquivo 03 permanece como referência técnica.
+
+## Decisões de arquitetura (ADRs)
+
+O plano é guiado por decisões registradas em [`../decisions/`](../decisions/).
+Ler antes de executar as tarefas de arquitetura:
+
+- [ADR 0001 — Core mínimo (loop) + módulos opcionais](../decisions/0001-modular-core-vs-modules.md):
+  o core é só o game loop + portas; roteamento e física são módulos opt-in no
+  mesmo repo. Reformula a tarefa 05 (dividida em 05a/05b) e absorve a 03.
+
+## Índice
+
+| # | Tarefa | Prioridade | Categoria |
+|---|--------|------------|-----------|
+| 01 | [Adicionar `override` em todas as sobrescritas](01-add-override.md) | 🔴 Alta | Boas práticas |
+| 02 | [Corrigir nomes invertidos (`shouldExit`, `isNextState…`)](02-fix-inverted-names.md) | 🔴 Alta | Boas práticas |
+| 03 | [Introduzir namespaces](03-namespace.md) *(absorvida pela 05a)* | 🟡 Média | Arquitetura |
+| 04 | [`const`-correctness + remover logging da lib](04-const-and-logging.md) | 🟡 Média | Boas práticas |
+| 05a | [Reorganização estrutural: `core` + `routing`](05a-restructure-modules.md) | 🔴 Alta (arq.) | Arquitetura |
+| 05b | [Redesenhar o `IRouter`](05b-redesign-irouter.md) | 🔴 Alta (arq.) | Arquitetura |
+| 06 | [Corrigir ciclo de vida / referências de cena](06-scene-lifetime.md) | 🟡 Média | Arquitetura |
+| 07 | [Alinhar padrão C++ entre cengine e consumidores](07-cpp-standard.md) | 🟡 Média | Ecossistema |
+| 08 | [Presets portáveis + CI (Debug + sanitizers)](08-presets-and-ci.md) | 🟢 Baixa | Ecossistema |
+| 09 | [Higiene de código (includes, código morto)](09-code-hygiene.md) | 🟢 Baixa | Boas práticas |
+| 10 | [Eliminar magic string e estados *stringly-typed*](10-typed-states.md) | 🟢 Baixa | Boas práticas |
+| 11 | [Documentação (Doxygen + uso no README)](11-documentation.md) | 🟢 Baixa | Documentação |
+
+## Legenda de status
+
+Marque no topo de cada arquivo conforme avança:
+`todo` → `in-progress` → `done`

--- a/README.md
+++ b/README.md
@@ -13,3 +13,22 @@ Ideal for exploring concepts such as:
 * Component-based architecture foundations
 
 Note: CEngine is part of a larger personal project and is under active experimentation.
+
+## Working context (`.ai/`)
+
+The [`.ai/`](.ai/) folder is the starting point for understanding **what is being
+worked on and where we are** in the engine's improvement effort. Read it before
+making changes:
+
+* [`.ai/task/README.md`](.ai/task/README.md) — the improvement plan: one file per
+  task, ordered by recommended development sequence (from the highest-impact
+  architectural work down to cleanup), each with problem, steps, and acceptance
+  criteria.
+* [`.ai/decisions/`](.ai/decisions/) — Architecture Decision Records (ADRs) that
+  guide the plan. Start with
+  [ADR 0001 — minimal core (loop) + optional modules](.ai/decisions/0001-modular-core-vs-modules.md):
+  the core is just the game loop + ports; routing and physics are opt-in modules
+  in the same repo.
+* [`.ai/build-and-test.md`](.ai/build-and-test.md) — verified build & test
+  environment (toolchain, reproducible commands, current status). The test suite
+  is the safety net: rebuild and run `ctest` after every task.

--- a/src/main/engine/GameManager.hpp
+++ b/src/main/engine/GameManager.hpp
@@ -14,5 +14,5 @@ public:
     void onExit() override;
 
     [[nodiscard]] bool shouldExist() const override;
-    void cleanup();
+    void cleanup() override;
 };

--- a/src/main/engine/service/impl/RouterInMemory.hpp
+++ b/src/main/engine/service/impl/RouterInMemory.hpp
@@ -15,19 +15,19 @@ public:
     explicit RouterInMemory(std::shared_ptr<ISceneRepository> sceneRepository);
     ~RouterInMemory() override = default;
 
-    void setNextState(std::unique_ptr<IState> state) const;
+    void setNextState(std::unique_ptr<IState> state) const override;
 
-    [[nodiscard]] IState& getCurrentStateGame() const;
-    [[nodiscard]] std::string getCurrentStateGameName() const;
-    [[nodiscard]] std::string getCurrentStateGameCode() const;
-    [[nodiscard]] IScene& getCurrentCachedScreen() const;
+    [[nodiscard]] IState& getCurrentStateGame() const override;
+    [[nodiscard]] std::string getCurrentStateGameName() const override;
+    [[nodiscard]] std::string getCurrentStateGameCode() const override;
+    [[nodiscard]] IScene& getCurrentCachedScreen() const override;
 
-    [[nodiscard]] IState& getNextStateGame() const;
-    [[nodiscard]] std::string getNextStateGameName() const;
-    [[nodiscard]] std::string getNextStateGameCode() const;
-    [[nodiscard]] IScene& getNextCachedScreen() const;
+    [[nodiscard]] IState& getNextStateGame() const override;
+    [[nodiscard]] std::string getNextStateGameName() const override;
+    [[nodiscard]] std::string getNextStateGameCode() const override;
+    [[nodiscard]] IScene& getNextCachedScreen() const override;
 
-    [[nodiscard]] bool hasNextScreen() const;
+    [[nodiscard]] bool hasNextScreen() const override;
 
-    void goToNextScreen() const;
+    void goToNextScreen() const override;
 };


### PR DESCRIPTION
## Objetivo

Estabelece o **plano de melhoria** da engine em `.ai/` e executa a **primeira
tarefa** dele (a rede de segurança de `override`), sem alterar comportamento.

## O que entra

### 1. Plano de melhoria (`.ai/`) — commit de docs
- `.ai/task/` — uma tarefa por arquivo, na ordem de desenvolvimento recomendada
  (problema, passos, critérios de aceite e riscos em cada uma).
- `.ai/decisions/0001-modular-core-vs-modules.md` — **ADR 0001**: o core é só o
  game loop + portas; roteamento e física viram **módulos opt-in** no mesmo repo
  (`cengine::core` + `cengine::routing`). Direção de dependência: core não
  depende de módulo; módulo depende do core; o jogo escolhe o que linkar.
- `.ai/build-and-test.md` — ambiente de build/testes verificado (toolchain,
  comandos reproduzíveis, status).
- A tarefa 05 foi dividida em **05a** (reorganização estrutural, *move puro*) e
  **05b** (redesenho do `IRouter`); a tarefa 03 (namespace) foi **absorvida** pela
  05a. README principal passa a apontar a pasta `.ai/` como ponto de partida.

### 2. Tarefa 01 — `override` specifiers — commit de código
- `RouterInMemory.hpp`: `override` nos 11 métodos herdados de `IRouter`.
- `GameManager.hpp`: `cleanup()` agora é `override`.
- `SceneRepository.hpp`: já estava 100% coberto (sem mudança).

## Verificação
- Build limpo (GCC 15.1.0 / MSYS2 UCRT64, CMake + Ninja).
- **`ctest`: 30/30 testes verdes.**
- Nenhum `override` gerou erro de compilação → **não havia** mismatch de
  assinatura escondido.

## Notas
- Mudança de comportamento: **nenhuma**. Só documentação + hardening de assinaturas.
- Próximo passo do plano: **05a** (reorganização em `core`/`routing`), que será
  *breaking* para consumidores (bump previsto `0.1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)