### PR TITLE
[codex] Redesign routing interface

### DIFF
--- a/.ai/build-and-test.md
+++ b/.ai/build-and-test.md
@@ -6,7 +6,7 @@ com segurança (rodar `ctest` a cada tarefa).
 
 - **Data da verificação:** 2026-07-04
 - **Plataforma:** Windows 11 Pro
-- **Resultado:** ✅ **30/30 testes passaram** (build limpo, sem warnings)
+- **Resultado:** ✅ **28/28 testes passaram** (build limpo, sem warnings)
 
 ## Toolchain confirmada
 
@@ -62,15 +62,15 @@ out/build/msys2-mingw/tests/cengine_tests.exe
 -- Generating done (0.1s)
 [100%] Built target cengine_tests
 ...
-100% tests passed, 0 tests failed out of 30
+100% tests passed, 0 tests failed out of 28
 Total Test time (real) = 0.20 sec
 ```
 
-## Cobertura da suíte (30 testes)
+## Cobertura da suíte (28 testes)
 
 - `SceneRepositoryTest` — registro/instanciação lazy via factory, unload,
   clone de estado, comparação de estados.
-- `RouterInMemoryTest` — delegação do Router para o repositório.
+- `RouterInMemoryTest` — API enxuta do Router e delegação para o repositório.
 - `GameManagerTest` — ciclo `onEnter/render/input/onExit` e condição de saída.
 - `EngineManagerTest` + `EngineManagerIntegrationTest` — loop principal validado
   por **call-log** (ordem exata das chamadas).
@@ -81,7 +81,7 @@ Total Test time (real) = 0.20 sec
    caminhos absolutos hardcoded (`C:/msys64/ucrt64/...`) que batem com esta
    máquina; numa máquina limpa falharia. → **[Tarefa 08](task/08-presets-and-ci.md)**.
 
-2. **Rede de segurança sólida.** Os 30 testes (incl. integração por call-log)
+2. **Rede de segurança sólida.** Os 28 testes (incl. integração por call-log)
    dão confiança para a cirurgia do `IRouter`. → **[Tarefa 05](task/05-redesign-irouter.md)**.
 
 3. **Os nomes dos próprios testes carregam os bugs de nomenclatura:**

--- a/.ai/task/02-fix-inverted-names.md
+++ b/.ai/task/02-fix-inverted-names.md
@@ -6,6 +6,10 @@
 - **Depende de:** 01 (rede de segurança de `override` já ativa)
 - **Bloqueia:** 05 (o redesenho do Router fica mais claro com nomes corretos)
 
+> Nota 2026-07-04: a parte 2.2 (`isNextStateEqualsToCurrentScene` ->
+> `hasPendingStateChange`) foi executada dentro da tarefa 05b. Esta tarefa ainda
+> precisa resolver `shouldExist()` -> `shouldExit()`.
+
 ## Problema
 
 Dois nomes dizem o **oposto** do que o código faz — a maior fonte de confusão

--- a/.ai/task/04-const-and-logging.md
+++ b/.ai/task/04-const-and-logging.md
@@ -7,6 +7,12 @@
 - **Bloqueia:** 05 (o Router será redesenhado; melhor entrar nele já com a
   semântica de `const` correta)
 
+> Nota 2026-07-04: os mutadores antigos do `IRouter`
+> (`setNextState`, `goToNextScreen`) foram substituidos na tarefa 05b por
+> `requestState` e `commitStateChange`, ambos nao-`const`. Esta tarefa ainda
+> precisa remover o logging direto de `GameManager::cleanup()` e revisar qualquer
+> `const` remanescente fora da API do router.
+
 ## Problema
 
 ### 4.1 `const` que mente

--- a/.ai/task/05b-redesign-irouter.md
+++ b/.ai/task/05b-redesign-irouter.md
@@ -1,32 +1,28 @@
-# 05b — Redesenhar o `IRouter` (dentro de `cengine::routing`)
+# 05b - Redesenhar o `IRouter` (dentro de `cengine::routing`)
 
-- **Status:** todo
-- **Prioridade:** 🔴 Alta (arquitetural)
+- **Status:** done (2026-07-04, branch `feature/05b-redesign-irouter`)
+- **Prioridade:** Alta (arquitetural)
 - **Categoria:** Arquitetura
-- **Depende de:** 05a (estrutura modular já pronta)
+- **Depende de:** 05a (estrutura modular ja pronta)
 - **Bloqueia:** 06
-- **Decisão de referência:** [ADR 0001](../decisions/0001-modular-core-vs-modules.md)
+- **Decisao de referencia:** [ADR 0001](../decisions/0001-modular-core-vs-modules.md)
 
-> A 05a já **moveu** o roteamento para `cengine::routing` sem mudar comportamento.
-> Esta tarefa faz a **limpeza de design** do roteador — agora isolada no módulo,
-> sem risco de contaminar o core.
+> A 05a moveu o roteamento para `cengine::routing` sem mudar comportamento.
+> Esta tarefa faz a limpeza de design do roteador dentro do modulo.
 
-## Problemas de desenho a corrigir
+## Problemas corrigidos
 
-Arquivo (após a 05a): `modules/routing/…/IRouter.hpp`
+Arquivo: `modules/routing/include/cengine/routing/IRouter.hpp`
 
-1. **Interface gorda (viola ISP).** ~12 métodos, com 6 pares quase idênticos
-   `getCurrent* / getNext*`. Os `...Name` e `...Code` são só delegação para
-   `IState::getName()/getCode()` — não precisam estar na interface do Router.
+1. **Interface gorda (viola ISP).** A interface saiu de ~12 metodos para 5:
+   `requestState`, `hasPendingStateChange`, `commitStateChange`, `currentState`
+   e `currentScene`.
+2. **Acoplamento entre portas.** `IRouter.hpp` nao inclui mais
+   `ISceneRepository.hpp`; usa forward declarations para `IState` e `IScene`.
+3. **Vocabulario Scene vs Screen.** A API publica do router passou a falar
+   `Scene`: `currentScene`, `hasPendingStateChange`, `commitStateChange`.
 
-2. **Acoplamento entre portas.** `IRouter.hpp` inclui
-   `repository/ISceneRepository.hpp`. Resolver com forward declaration + injeção.
-
-3. **Vocabulário Scene vs Screen.** Unificar em **Scene** (alinha com
-   `IScene`/`SceneRepository`), eliminando "Screen"
-   (`getCurrentCachedScreen`→`currentScene`, `hasNextScreen`, `goToNextScreen`).
-
-## Direção de design proposta (revisar antes de codar)
+## API resultante
 
 ```cpp
 namespace cengine::routing {
@@ -34,43 +30,56 @@ class IRouter {
 public:
     virtual ~IRouter() = default;
 
-    void requestState(std::unique_ptr<IState> next);          // ex-setNextState
-    [[nodiscard]] bool hasPendingStateChange() const;         // ex-hasNextScreen
-    void commitStateChange();                                 // ex-goToNextScreen
+    virtual void requestState(std::unique_ptr<IState> state) = 0;
+    [[nodiscard]] virtual bool hasPendingStateChange() const = 0;
+    virtual void commitStateChange() = 0;
 
-    [[nodiscard]] IState& currentState() const;
-    [[nodiscard]] IScene& currentScene() const;
+    [[nodiscard]] virtual const IState& currentState() const = 0;
+    [[nodiscard]] virtual core::IScene& currentScene() = 0;
 };
 }
 ```
 
-- `...Name`/`...Code` saem: quem precisar chama `currentState().getName()/getCode()`.
-- `getNext*` só permanece se houver caso de uso real de espiar a próxima cena
-  antes do commit; senão, remover (YAGNI).
-- Confirmar o conjunto mínimo consultando **todos** os chamadores reais
-  (hoje: `GameManager`).
+Notas de design:
 
-## Passos
+- `currentState()` retorna `const IState&`, porque callers nao devem mutar o
+  estado atual pelo router.
+- `currentScene()` nao e `const`, porque o acesso pode instanciar a cena lazy via
+  repository e retorna uma cena mutavel para o ciclo `onEnter/input/render/onExit`.
+- `getNext*` foi removido por falta de caller real.
+- `...Name`/`...Code` foram removidos; callers usam `currentState().getCode()`
+  ou `currentState().getName()` quando necessario.
 
-1. Levantar (grep) os chamadores reais de cada método de `IRouter`.
-2. Validar o desenho enxuto acima.
-3. Reescrever `RouterInMemory`; mover as delegações `...Name/...Code` para os
-   chamadores.
-4. Remover o include de `ISceneRepository.hpp` do header de `IRouter`.
-5. Renomear Screen → Scene em toda a cadeia (Router, GameManager, testes).
-6. Atualizar `MockRouter` e os testes.
-7. Atualizar o consumidor de referência (8Puzzle) para a nova API + link
-   `cengine::routing`.
+## Resultado da execucao
 
-## Critérios de aceite
+- `IRouter` reduzido para 5 metodos coesos.
+- `RouterInMemory` reescrito para a nova API.
+- `GameManager` atualizado para `currentScene()`, `hasPendingStateChange()` e
+  `commitStateChange()`.
+- `ISceneRepository::isNextStateEqualsToCurrentScene()` renomeado para
+  `hasPendingStateChange()` para alinhar nome e semantica.
+- `MockRouter`, `MockSceneRepository` e testes de routing atualizados.
+- Testes de delegacao removidos quando cobriam apenas metodos que deixaram de
+  existir (`getCurrentStateGameName`, `getCurrentStateGameCode`).
 
-- [ ] `IRouter` com no máximo ~5–6 métodos coesos.
-- [ ] `IRouter.hpp` não inclui `ISceneRepository.hpp`.
-- [ ] Vocabulário único (Scene).
-- [ ] Testes de integração do loop passam **sem mudança de comportamento**.
+## Criterios de aceite
 
-## Riscos
+- [x] `IRouter` com no maximo ~5-6 metodos coesos.
+- [x] `IRouter.hpp` nao inclui `ISceneRepository.hpp`.
+- [x] Vocabulario unico (Scene) na API do router.
+- [x] Testes de integracao do loop passam sem mudanca de comportamento.
 
-Médio/Alto — mexe em interface pública do módulo. Mitigadores: 01–04 estabilizaram
-o terreno, 05a isolou o roteamento, e o `EngineManagerIntegrationTest` trava
-regressão de comportamento por call-log.
+## Verificacao
+
+- `cmake --build --preset msys2-mingw`
+- `ctest --test-dir out/build/msys2-mingw --output-on-failure`
+- Resultado: 28/28 testes passaram.
+
+## Pendencias fora do escopo
+
+- Atualizar o consumidor de referencia 8Puzzle para a nova API do router e para
+  o target `cengine::routing` quando esse repositorio estiver no workspace.
+- `IGameManager::shouldExist()` continua com nome invertido; fica para a tarefa
+  02.
+- `GameManager::cleanup()` ainda escreve em `std::cout`; fica para a tarefa 04.
+- A tarefa 06 deve decidir a estrategia de lifetime das cenas sobre a API nova.

--- a/modules/routing/include/cengine/routing/IRouter.hpp
+++ b/modules/routing/include/cengine/routing/IRouter.hpp
@@ -1,32 +1,24 @@
 #pragma once
 #include <memory>
-#include <string>
 
-#include <cengine/core/IScene.hpp>
-#include <cengine/routing/IState.hpp>
-#include <cengine/routing/ISceneRepository.hpp>
+namespace cengine::core {
+class IScene;
+}
 
 namespace cengine::routing {
+
+class IState;
 
 class IRouter {
 public:
     virtual ~IRouter() = default;
 
-    virtual void setNextState(std::unique_ptr<IState> state) const = 0;
+    virtual void requestState(std::unique_ptr<IState> state) = 0;
+    [[nodiscard]] virtual bool hasPendingStateChange() const = 0;
+    virtual void commitStateChange() = 0;
 
-    [[nodiscard]] virtual IState& getCurrentStateGame() const = 0;
-    [[nodiscard]] virtual std::string getCurrentStateGameName() const = 0;
-    [[nodiscard]] virtual std::string getCurrentStateGameCode() const = 0;
-    [[nodiscard]] virtual core::IScene& getCurrentCachedScreen() const = 0;
-
-    [[nodiscard]] virtual IState& getNextStateGame() const = 0;
-    [[nodiscard]] virtual std::string getNextStateGameName() const = 0;
-    [[nodiscard]] virtual std::string getNextStateGameCode() const = 0;
-    [[nodiscard]] virtual core::IScene& getNextCachedScreen() const = 0;
-
-    [[nodiscard]] virtual bool hasNextScreen() const = 0;
-
-    virtual void goToNextScreen() const = 0;
+    [[nodiscard]] virtual const IState& currentState() const = 0;
+    [[nodiscard]] virtual core::IScene& currentScene() = 0;
 };
 
 } // namespace cengine::routing

--- a/modules/routing/include/cengine/routing/ISceneRepository.hpp
+++ b/modules/routing/include/cengine/routing/ISceneRepository.hpp
@@ -20,7 +20,7 @@ public:
     virtual core::IScene& getScene(const std::string& name) = 0;
     virtual void unloadScene(const std::string& name) = 0;
     virtual void unloadAll() = 0;
-    virtual bool isNextStateEqualsToCurrentScene() const = 0;
+    virtual bool hasPendingStateChange() const = 0;
 };
 
 } // namespace cengine::routing

--- a/modules/routing/include/cengine/routing/RouterInMemory.hpp
+++ b/modules/routing/include/cengine/routing/RouterInMemory.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <memory>
-#include <string>
 
 #include <cengine/core/IScene.hpp>
 #include <cengine/routing/IState.hpp>
@@ -16,21 +15,12 @@ public:
     explicit RouterInMemory(std::shared_ptr<ISceneRepository> sceneRepository);
     ~RouterInMemory() override = default;
 
-    void setNextState(std::unique_ptr<IState> state) const override;
+    void requestState(std::unique_ptr<IState> state) override;
+    [[nodiscard]] bool hasPendingStateChange() const override;
+    void commitStateChange() override;
 
-    [[nodiscard]] IState& getCurrentStateGame() const override;
-    [[nodiscard]] std::string getCurrentStateGameName() const override;
-    [[nodiscard]] std::string getCurrentStateGameCode() const override;
-    [[nodiscard]] core::IScene& getCurrentCachedScreen() const override;
-
-    [[nodiscard]] IState& getNextStateGame() const override;
-    [[nodiscard]] std::string getNextStateGameName() const override;
-    [[nodiscard]] std::string getNextStateGameCode() const override;
-    [[nodiscard]] core::IScene& getNextCachedScreen() const override;
-
-    [[nodiscard]] bool hasNextScreen() const override;
-
-    void goToNextScreen() const override;
+    [[nodiscard]] const IState& currentState() const override;
+    [[nodiscard]] core::IScene& currentScene() override;
 };
 
 } // namespace cengine::routing

--- a/modules/routing/include/cengine/routing/SceneRepository.hpp
+++ b/modules/routing/include/cengine/routing/SceneRepository.hpp
@@ -38,7 +38,7 @@ public:
 
     void unloadAll() override;
 
-    bool isNextStateEqualsToCurrentScene() const override;
+    bool hasPendingStateChange() const override;
 };
 
 } // namespace cengine::routing

--- a/modules/routing/src/GameManager.cpp
+++ b/modules/routing/src/GameManager.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <utility>
 
+#include <cengine/routing/IState.hpp>
 #include <cengine/routing/IRouter.hpp>
 
 namespace cengine::routing {
@@ -12,34 +13,34 @@ namespace cengine::routing {
 GameManager::GameManager(std::shared_ptr<IRouter> routerService) : m_routerService(std::move(routerService)){}
 
 void GameManager::onEnter() {
-    if (core::IScene& screen = m_routerService->getCurrentCachedScreen(); !screen.isOnEnterExecuted()) {
-        screen.onEnter();
-        screen.onEnterExecuted();
+    if (core::IScene& scene = m_routerService->currentScene(); !scene.isOnEnterExecuted()) {
+        scene.onEnter();
+        scene.onEnterExecuted();
     }
 }
 
 void GameManager::render() {
-    core::IScene& screen = m_routerService->getCurrentCachedScreen();
+    core::IScene& scene = m_routerService->currentScene();
 
-    screen.draw();
+    scene.draw();
 }
 
 void GameManager::input() {
-    core::IScene& screen = m_routerService->getCurrentCachedScreen();
+    core::IScene& scene = m_routerService->currentScene();
 
-    screen.input();
+    scene.input();
 }
 
 void GameManager::onExit() {
-    if (m_routerService->hasNextScreen()) {
-        core::IScene& screen = m_routerService->getCurrentCachedScreen();
-        screen.onExit();
-        m_routerService->goToNextScreen();
+    if (m_routerService->hasPendingStateChange()) {
+        core::IScene& scene = m_routerService->currentScene();
+        scene.onExit();
+        m_routerService->commitStateChange();
     }
 }
 
 bool GameManager::shouldExist() const {
-    return m_routerService->getCurrentStateGameCode() == "exit";
+    return m_routerService->currentState().getCode() == "exit";
 }
 
 void GameManager::cleanup() {

--- a/modules/routing/src/RouterInMemory.cpp
+++ b/modules/routing/src/RouterInMemory.cpp
@@ -1,54 +1,32 @@
 #include <cengine/routing/RouterInMemory.hpp>
 
+#include <string>
 #include <utility>
 
 namespace cengine::routing {
 
 RouterInMemory::RouterInMemory(std::shared_ptr<ISceneRepository> sceneRepository) : m_sceneRepository(std::move(sceneRepository)) {}
 
-void RouterInMemory::setNextState(std::unique_ptr<IState> state) const {
+void RouterInMemory::requestState(std::unique_ptr<IState> state) {
     m_sceneRepository->persistNextState(std::move(state));
 }
 
-IState &RouterInMemory::getCurrentStateGame() const {
+bool RouterInMemory::hasPendingStateChange() const {
+    return m_sceneRepository->hasPendingStateChange();
+}
+
+void RouterInMemory::commitStateChange() {
+    const std::string currentStateCode = m_sceneRepository->getCurrentStateGame().getCode();
+    m_sceneRepository->unloadScene(currentStateCode);
+    m_sceneRepository->persisteCurrentState();
+}
+
+const IState& RouterInMemory::currentState() const {
     return m_sceneRepository->getCurrentStateGame();
 }
 
-std::string RouterInMemory::getCurrentStateGameName() const {
-    return m_sceneRepository->getCurrentStateGame().getName();
-}
-
-std::string RouterInMemory::getCurrentStateGameCode() const {
-    return m_sceneRepository->getCurrentStateGame().getCode();
-}
-
-core::IScene &RouterInMemory::getCurrentCachedScreen() const {
-    return m_sceneRepository->getScene(getCurrentStateGameCode());
-}
-
-IState &RouterInMemory::getNextStateGame() const {
-    return m_sceneRepository->getNextStateGame();
-}
-
-std::string RouterInMemory::getNextStateGameName() const {
-    return m_sceneRepository->getNextStateGame().getName();
-}
-
-std::string RouterInMemory::getNextStateGameCode() const {
-    return m_sceneRepository->getNextStateGame().getCode();
-}
-
-core::IScene &RouterInMemory::getNextCachedScreen() const {
-    return m_sceneRepository->getScene(getNextStateGameCode());
-}
-
-bool RouterInMemory::hasNextScreen() const {
-    return m_sceneRepository->isNextStateEqualsToCurrentScene();
-}
-
-void RouterInMemory::goToNextScreen() const {
-    m_sceneRepository->unloadScene(getCurrentStateGameCode());
-    m_sceneRepository->persisteCurrentState();
+core::IScene& RouterInMemory::currentScene() {
+    return m_sceneRepository->getScene(currentState().getCode());
 }
 
 } // namespace cengine::routing

--- a/modules/routing/src/SceneRepository.cpp
+++ b/modules/routing/src/SceneRepository.cpp
@@ -53,7 +53,7 @@ void SceneRepository::unloadAll() {
     m_scenes.clear();
 }
 
-bool SceneRepository::isNextStateEqualsToCurrentScene() const {
+bool SceneRepository::hasPendingStateChange() const {
     return m_nextState->getCode() != m_currentState->getCode();
 }
 

--- a/tests/mock/MockRouter.hpp
+++ b/tests/mock/MockRouter.hpp
@@ -7,15 +7,9 @@
 
 class MockRouter : public cengine::routing::IRouter {
 public:
-    MOCK_METHOD(void, setNextState, (std::unique_ptr<cengine::routing::IState>), (const, override));
-    MOCK_METHOD(cengine::routing::IState&, getCurrentStateGame, (), (const, override));
-    MOCK_METHOD(std::string, getCurrentStateGameName, (), (const, override));
-    MOCK_METHOD(std::string, getCurrentStateGameCode, (), (const, override));
-    MOCK_METHOD(cengine::core::IScene&, getCurrentCachedScreen, (), (const, override));
-    MOCK_METHOD(cengine::routing::IState&, getNextStateGame, (), (const, override));
-    MOCK_METHOD(std::string, getNextStateGameName, (), (const, override));
-    MOCK_METHOD(std::string, getNextStateGameCode, (), (const, override));
-    MOCK_METHOD(cengine::core::IScene&, getNextCachedScreen, (), (const, override));
-    MOCK_METHOD(bool, hasNextScreen, (), (const, override));
-    MOCK_METHOD(void, goToNextScreen, (), (const, override));
+    MOCK_METHOD(void, requestState, (std::unique_ptr<cengine::routing::IState>), (override));
+    MOCK_METHOD(bool, hasPendingStateChange, (), (const, override));
+    MOCK_METHOD(void, commitStateChange, (), (override));
+    MOCK_METHOD(const cengine::routing::IState&, currentState, (), (const, override));
+    MOCK_METHOD(cengine::core::IScene&, currentScene, (), (override));
 };

--- a/tests/mock/MockSceneRepository.hpp
+++ b/tests/mock/MockSceneRepository.hpp
@@ -15,5 +15,5 @@ public:
     MOCK_METHOD(cengine::core::IScene&, getScene, (const std::string& name), (override));
     MOCK_METHOD(void, unloadScene, (const std::string& name), (override));
     MOCK_METHOD(void, unloadAll, (), (override));
-    MOCK_METHOD(bool, isNextStateEqualsToCurrentScene, (), (const, override));
+    MOCK_METHOD(bool, hasPendingStateChange, (), (const, override));
 };

--- a/tests/routing/GameManagerTest.cpp
+++ b/tests/routing/GameManagerTest.cpp
@@ -5,122 +5,88 @@
 #include <string>
 
 #include <cengine/core/IScene.hpp>
-
-#include <mock/MockScene.hpp>
-#include <mock/MockRouter.hpp>
-
 #include <cengine/routing/GameManager.hpp>
+
+#include <mock/MockRouter.hpp>
+#include <mock/MockScene.hpp>
+#include <mock/MockState.hpp>
 
 using namespace cengine::core;
 using namespace cengine::routing;
 
-// Fixture para os testes de GameManager
 class GameManagerTest : public ::testing::Test {
 protected:
     std::shared_ptr<MockRouter> m_mockRouter;
     std::unique_ptr<GameManager> m_gameManager;
     MockScene m_mockScene;
+    MockState m_mockState;
 
     void SetUp() override {
-        // Inicializa os mocks e a classe a ser testada
         m_mockRouter = std::make_shared<MockRouter>();
         m_gameManager = std::make_unique<GameManager>(m_mockRouter);
     }
 };
 
-// Teste para o método onEnter() quando a tela ainda não foi inicializada
-TEST_F(GameManagerTest, OnEnter_WhenScreenNotInitialized_CallsOnEnter) {
-    // Expectativas para o mock do roteador
-    EXPECT_CALL(*m_mockRouter, getCurrentCachedScreen()).WillOnce(testing::ReturnRef(m_mockScene));
-    // Expectativas para o mock da cena
+TEST_F(GameManagerTest, OnEnter_WhenSceneNotInitialized_CallsOnEnter) {
+    EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
     EXPECT_CALL(m_mockScene, isOnEnterExecuted()).WillOnce(testing::Return(false));
     EXPECT_CALL(m_mockScene, onEnter()).Times(1);
     EXPECT_CALL(m_mockScene, onEnterExecuted()).Times(1);
 
-    // Chama o método a ser testado
     m_gameManager->onEnter();
 }
 
-// Teste para o método onEnter() quando a tela já foi inicializada
-TEST_F(GameManagerTest, OnEnter_WhenScreenAlreadyInitialized_DoesNothing) {
-    // Expectativas para o mock do roteador
-    EXPECT_CALL(*m_mockRouter, getCurrentCachedScreen()).WillOnce(testing::ReturnRef(m_mockScene));
-
-    // Expectativas para o mock da cena
+TEST_F(GameManagerTest, OnEnter_WhenSceneAlreadyInitialized_DoesNothing) {
+    EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
     EXPECT_CALL(m_mockScene, isOnEnterExecuted()).WillOnce(testing::Return(true));
     EXPECT_CALL(m_mockScene, onEnter()).Times(0);
     EXPECT_CALL(m_mockScene, onEnterExecuted()).Times(0);
 
-    // Chama o método a ser testado
     m_gameManager->onEnter();
 }
 
-// Teste para o método render()
-TEST_F(GameManagerTest, Render_CallsDrawOnCurrentScreen) {
-    // Expectativa para o mock do roteador
-    EXPECT_CALL(*m_mockRouter, getCurrentCachedScreen()).WillOnce(testing::ReturnRef(m_mockScene));
-
-    // Expectativa para o mock da cena
+TEST_F(GameManagerTest, Render_CallsDrawOnCurrentScene) {
+    EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
     EXPECT_CALL(m_mockScene, draw()).Times(1);
 
-    // Chama o método a ser testado
     m_gameManager->render();
 }
 
-// Teste para o método input()
-TEST_F(GameManagerTest, Input_CallsInputOnCurrentScreen) {
-    // Expectativa para o mock do roteador
-    EXPECT_CALL(*m_mockRouter, getCurrentCachedScreen()).WillOnce(testing::ReturnRef(m_mockScene));
-
-    // Expectativa para o mock da cena
+TEST_F(GameManagerTest, Input_CallsInputOnCurrentScene) {
+    EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
     EXPECT_CALL(m_mockScene, input()).Times(1);
 
-    // Chama o método a ser testado
     m_gameManager->input();
 }
 
-// Teste para o método onExit() quando há uma próxima tela
-TEST_F(GameManagerTest, OnExit_WhenNextScreenExists_CallsOnExitAndGoToNext) {
-    // Expectativas para o mock do roteador
-    EXPECT_CALL(*m_mockRouter, hasNextScreen()).WillOnce(testing::Return(true));
-    EXPECT_CALL(*m_mockRouter, getCurrentCachedScreen()).WillOnce(testing::ReturnRef(m_mockScene));
-    EXPECT_CALL(*m_mockRouter, goToNextScreen()).Times(1);
-
-    // Expectativa para o mock da cena
+TEST_F(GameManagerTest, OnExit_WhenPendingStateChangeExists_CallsOnExitAndCommits) {
+    EXPECT_CALL(*m_mockRouter, hasPendingStateChange()).WillOnce(testing::Return(true));
+    EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
+    EXPECT_CALL(*m_mockRouter, commitStateChange()).Times(1);
     EXPECT_CALL(m_mockScene, onExit()).Times(1);
 
-    // Chama o método a ser testado
     m_gameManager->onExit();
 }
 
-// Teste para o método onExit() quando não há uma próxima tela
-TEST_F(GameManagerTest, OnExit_WhenNextScreenDoesNotExist_DoesNothing) {
-    // Expectativa para o mock do roteador
-    EXPECT_CALL(*m_mockRouter, hasNextScreen()).WillOnce(testing::Return(false));
-    EXPECT_CALL(*m_mockRouter, getCurrentCachedScreen()).Times(0);
-    EXPECT_CALL(*m_mockRouter, goToNextScreen()).Times(0);
-
-    // Expectativa para o mock da cena
+TEST_F(GameManagerTest, OnExit_WhenPendingStateChangeDoesNotExist_DoesNothing) {
+    EXPECT_CALL(*m_mockRouter, hasPendingStateChange()).WillOnce(testing::Return(false));
+    EXPECT_CALL(*m_mockRouter, currentScene()).Times(0);
+    EXPECT_CALL(*m_mockRouter, commitStateChange()).Times(0);
     EXPECT_CALL(m_mockScene, onExit()).Times(0);
 
-    // Chama o método a ser testado
     m_gameManager->onExit();
 }
 
-// Teste para o método shouldExist() quando o código de estado é "exit"
 TEST_F(GameManagerTest, ShouldExist_WhenStateIsExit_ReturnsTrue) {
-    // Expectativa para o mock do roteador
-    EXPECT_CALL(*m_mockRouter, getCurrentStateGameCode()).WillOnce(testing::Return("exit"));
+    EXPECT_CALL(*m_mockRouter, currentState()).WillOnce(testing::ReturnRef(m_mockState));
+    EXPECT_CALL(m_mockState, getCode()).WillOnce(testing::Return("exit"));
 
-    // Chama o método e verifica o retorno
     ASSERT_TRUE(m_gameManager->shouldExist());
 }
 
-// Teste para o método shouldExist() quando o código de estado não é "exit"
 TEST_F(GameManagerTest, ShouldExist_WhenStateIsNotExit_ReturnsFalse) {
-    // Expectativa para o mock do roteador
-    EXPECT_CALL(*m_mockRouter, getCurrentStateGameCode()).WillOnce(testing::Return("main_menu"));
+    EXPECT_CALL(*m_mockRouter, currentState()).WillOnce(testing::ReturnRef(m_mockState));
+    EXPECT_CALL(m_mockState, getCode()).WillOnce(testing::Return("main_menu"));
 
-    // Chama o método e verifica o retorno
     ASSERT_FALSE(m_gameManager->shouldExist());
 }

--- a/tests/routing/RouterInMemoryTest.cpp
+++ b/tests/routing/RouterInMemoryTest.cpp
@@ -1,126 +1,78 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+
 #include <memory>
 #include <string>
 
-#include <cengine/routing/IState.hpp>
 #include <cengine/core/IScene.hpp>
+#include <cengine/routing/IState.hpp>
+#include <cengine/routing/RouterInMemory.hpp>
 
 #include <mock/MockScene.hpp>
-#include <mock/MockState.hpp>
 #include <mock/MockSceneRepository.hpp>
-
-#include <cengine/routing/RouterInMemory.hpp>
+#include <mock/MockState.hpp>
 
 using namespace cengine::core;
 using namespace cengine::routing;
 
-// Fixture para a classe RouterServiceTest
 class RouterInMemoryTest : public ::testing::Test {
 protected:
     std::shared_ptr<MockSceneRepository> mockSceneRepository;
     std::unique_ptr<RouterInMemory> routerService;
 
-    // Mocks de dependências que os métodos de teste usarão
     MockState mockCurrentState;
     MockScene mockScene;
 
     void SetUp() override {
-        // Inicializa o mock do repositório
         mockSceneRepository = std::make_shared<MockSceneRepository>();
-        // Inicializa o serviço com o repositório mockado
         routerService = std::make_unique<RouterInMemory>(mockSceneRepository);
     }
 };
 
-// Teste: setNextState deve delegar a chamada para SceneRepository::persistNextState.
-TEST_F(RouterInMemoryTest, SetNextStateDelegatesToRepository) {
-    // 1. Cria um unique_ptr para o estado a ser passado
+TEST_F(RouterInMemoryTest, RequestStateDelegatesToRepository) {
     auto newState = std::make_unique<MockState>();
-    // 2. Define a expectativa de que o método persistNextState do mock será chamado.
+
     EXPECT_CALL(*mockSceneRepository, persistNextState(testing::A<std::unique_ptr<IState>>())).Times(1);
 
-    // 3. Chama o método do serviço
-    routerService->setNextState(std::move(newState));
+    routerService->requestState(std::move(newState));
 }
 
-// Teste: getCurrentStateGame deve delegar a chamada para SceneRepository::getCurrentStateGame.
-TEST_F(RouterInMemoryTest, GetCurrentStateGameDelegatesCorrectly) {
-    // 1. Define a expectativa de que o método será chamado e retornará uma referência para mockCurrentState.
+TEST_F(RouterInMemoryTest, CurrentStateDelegatesCorrectly) {
     EXPECT_CALL(*mockSceneRepository, getCurrentStateGame()).WillOnce(testing::ReturnRef(mockCurrentState));
-    // 2. Chama o método e verifica se o retorno é o esperado.
-    IState& returnedState = routerService->getCurrentStateGame();
+
+    const IState& returnedState = routerService->currentState();
+
     ASSERT_EQ(&returnedState, &mockCurrentState);
 }
 
-// Teste: getCurrentStateGameName deve delegar a chamada e retornar o nome correto.
-TEST_F(RouterInMemoryTest, GetCurrentStateGameNameDelegatesCorrectly) {
-    const std::string expectedName = "MenuState";
-    // 1. Define a expectativa que getCurrentStateGame() será chamado no repo.
-    EXPECT_CALL(*mockSceneRepository, getCurrentStateGame()).WillOnce(testing::ReturnRef(mockCurrentState));
-    // 2. Define a expectativa que getName() será chamado no mockCurrentState.
-    EXPECT_CALL(mockCurrentState, getName()).WillOnce(testing::Return(expectedName));
-
-    // 3. Chama o método e verifica se o nome retornado é o esperado.
-    std::string returnedName = routerService->getCurrentStateGameName();
-    ASSERT_EQ(returnedName, expectedName);
-}
-
-// Teste: getCurrentStateGameCode deve delegar a chamada e retornar o código correto.
-TEST_F(RouterInMemoryTest, GetCurrentStateGameCodeDelegatesCorrectly) {
+TEST_F(RouterInMemoryTest, CurrentSceneDelegatesCorrectly) {
     const std::string expectedCode = "MENU";
-    // 1. Define a expectativa que getCurrentStateGame() será chamado no repo.
-    EXPECT_CALL(*mockSceneRepository, getCurrentStateGame()).WillOnce(testing::ReturnRef(mockCurrentState));
-    // 2. Define a expectativa que getCode() será chamado no mockCurrentState.
-    EXPECT_CALL(mockCurrentState, getCode()).WillOnce(testing::Return(expectedCode));
 
-    // 3. Chama o método e verifica se o código retornado é o esperado.
-    std::string returnedCode = routerService->getCurrentStateGameCode();
-    ASSERT_EQ(returnedCode, expectedCode);
-}
-
-// Teste: getCurrentCachedScreen deve delegar a chamada e retornar a scene correta.
-TEST_F(RouterInMemoryTest, GetCurrentCachedScreenDelegatesCorrectly) {
-    const std::string expectedCode = "MENU";
-    // 1. Define a expectativa que getCurrentStateGame() será chamado e retornará um mock de estado.
     EXPECT_CALL(*mockSceneRepository, getCurrentStateGame()).WillOnce(testing::ReturnRef(mockCurrentState));
-    // 2. Define a expectativa que getCode() será chamado no mock do estado.
     EXPECT_CALL(mockCurrentState, getCode()).WillOnce(testing::Return(expectedCode));
-    // 3. Define a expectativa que getScene() será chamado no mock do repo com o código correto.
     EXPECT_CALL(*mockSceneRepository, getScene(expectedCode)).WillOnce(testing::ReturnRef(mockScene));
 
-    // 4. Chama o método e verifica se a cena retornada é a esperada.
-    IScene& returnedScene = routerService->getCurrentCachedScreen();
+    IScene& returnedScene = routerService->currentScene();
+
     ASSERT_EQ(&returnedScene, &mockScene);
 }
 
-// Teste: goToNextScreen deve chamar unloadScene e persisteCurrentState na ordem correta.
-TEST_F(RouterInMemoryTest, GoToNextScreenCallsMethodsInCorrectOrder) {
-    const std::string expectedCode = "OLD_SCREEN";
+TEST_F(RouterInMemoryTest, CommitStateChangeCallsMethodsInCorrectOrder) {
+    const std::string expectedCode = "OLD_SCENE";
+    testing::InSequence sequence;
 
-    // Usa InSequence para garantir a ordem das chamadas
-    testing::InSequence s;
-
-    // 1. Define a expectativa de que getCurrentStateGame() será chamado.
     EXPECT_CALL(*mockSceneRepository, getCurrentStateGame()).WillOnce(testing::ReturnRef(mockCurrentState));
-    // 2. Define a expectativa de que getCode() será chamado para obter o código da cena a ser descarregada.
     EXPECT_CALL(mockCurrentState, getCode()).WillOnce(testing::Return(expectedCode));
-    // 3. Define a expectativa de que unloadScene() será chamado com o código correto.
     EXPECT_CALL(*mockSceneRepository, unloadScene(expectedCode)).Times(1);
-    // 4. Define a expectativa de que persisteCurrentState() será chamado em seguida.
     EXPECT_CALL(*mockSceneRepository, persisteCurrentState()).Times(1);
 
-    // 5. Chama o método que orquestra as chamadas.
-    routerService->goToNextScreen();
+    routerService->commitStateChange();
 }
 
-// Teste: hasNextScreen deve delegar a chamada para isNextStateEqualsToCurrentScene e retornar o valor.
-TEST_F(RouterInMemoryTest, HasNextScreenDelegatesCorrectly) {
-    // 1. Define a expectativa de que isNextStateEqualsToCurrentScene() será chamado e retornará true.
-    EXPECT_CALL(*mockSceneRepository, isNextStateEqualsToCurrentScene()).WillOnce(testing::Return(true));
-    ASSERT_TRUE(routerService->hasNextScreen());
+TEST_F(RouterInMemoryTest, HasPendingStateChangeDelegatesCorrectly) {
+    EXPECT_CALL(*mockSceneRepository, hasPendingStateChange()).WillOnce(testing::Return(true));
+    ASSERT_TRUE(routerService->hasPendingStateChange());
 
-    // 2. Define a expectativa para a próxima chamada, retornando false.
-    EXPECT_CALL(*mockSceneRepository, isNextStateEqualsToCurrentScene()).WillOnce(testing::Return(false));
-    ASSERT_FALSE(routerService->hasNextScreen());
+    EXPECT_CALL(*mockSceneRepository, hasPendingStateChange()).WillOnce(testing::Return(false));
+    ASSERT_FALSE(routerService->hasPendingStateChange());
 }

--- a/tests/routing/SceneRepositoryTest.cpp
+++ b/tests/routing/SceneRepositoryTest.cpp
@@ -179,8 +179,8 @@ TEST_F(SceneRepositoryTest, PersistNextStateMovesNewState) {
 }
 
 
-// Teste: isNextStateEqualsToCurrentScene deve retornar true se os códigos de estado forem diferentes.
-TEST_F(SceneRepositoryTest, IsNextStateEqualsToCurrentSceneReturnsTrueIfCodesDifferent) {
+// Teste: hasPendingStateChange deve retornar true se os códigos de estado forem diferentes.
+TEST_F(SceneRepositoryTest, HasPendingStateChangeReturnsTrueIfCodesDifferent) {
     auto nextStateMock = std::make_unique<MockState>();
 
     // Define o comportamento de getCode() para os estados
@@ -192,11 +192,11 @@ TEST_F(SceneRepositoryTest, IsNextStateEqualsToCurrentSceneReturnsTrueIfCodesDif
     sceneRepository->persistNextState(std::move(nextStateMock));
 
     // A função deve retornar true porque os códigos são diferentes
-    EXPECT_TRUE(sceneRepository->isNextStateEqualsToCurrentScene());
+    EXPECT_TRUE(sceneRepository->hasPendingStateChange());
 }
 
-// Teste: isNextStateEqualsToCurrentScene deve retornar false se os códigos de estado forem iguais.
-TEST_F(SceneRepositoryTest, IsNextStateEqualsToCurrentSceneReturnsFalseIfCodesSame) {
+// Teste: hasPendingStateChange deve retornar false se os códigos de estado forem iguais.
+TEST_F(SceneRepositoryTest, HasPendingStateChangeReturnsFalseIfCodesSame) {
     auto nextStateMock = std::make_unique<MockState>();
 
     // Define o comportamento de getCode() para os estados
@@ -208,5 +208,5 @@ TEST_F(SceneRepositoryTest, IsNextStateEqualsToCurrentSceneReturnsFalseIfCodesSa
     sceneRepository->persistNextState(std::move(nextStateMock));
 
     // A função deve retornar false porque os códigos são os mesmos
-    EXPECT_FALSE(sceneRepository->isNextStateEqualsToCurrentScene());
+    EXPECT_FALSE(sceneRepository->hasPendingStateChange());
 }


### PR DESCRIPTION
## Summary

- Reduces `cengine::routing::IRouter` from the previous getter-heavy API to five cohesive operations: `requestState`, `hasPendingStateChange`, `commitStateChange`, `currentState`, and `currentScene`.
- Removes the `ISceneRepository` dependency from `IRouter.hpp` via forward declarations.
- Updates `RouterInMemory`, `GameManager`, mocks, and routing tests to the new Scene-oriented API.
- Renames the repository pending-state check from `isNextStateEqualsToCurrentScene` to `hasPendingStateChange`.
- Updates the 05b task notes and build/test documentation to reflect the new 28-test suite.

## Impact

This is a breaking API change for consumers of `cengine::routing`. Callers should use the new router methods and link against `cengine::routing` as before.

## Validation

- `cmake --build --preset msys2-mingw`
- `ctest --test-dir out/build/msys2-mingw --output-on-failure` - 28/28 passed
- `cmake --build out\build\core-only-no-tests`
- `git diff --check`