### PR TITLE
Limpeza de código: nomes, código morto, logging, magic string (02/04/09/10)

### DIFF
--- a/.ai/task/02-fix-inverted-names.md
+++ b/.ai/task/02-fix-inverted-names.md
@@ -1,14 +1,16 @@
 # 02 — Corrigir nomes invertidos e semântica enganosa
 
-- **Status:** todo
+- **Status:** done ✅ (2026-07-04, branch `feature/cleanup-02-04-09-10`)
 - **Prioridade:** 🔴 Alta
 - **Categoria:** Boas práticas / legibilidade
 - **Depende de:** 01 (rede de segurança de `override` já ativa)
-- **Bloqueia:** 05 (o redesenho do Router fica mais claro com nomes corretos)
 
-> Nota 2026-07-04: a parte 2.2 (`isNextStateEqualsToCurrentScene` ->
-> `hasPendingStateChange`) foi executada dentro da tarefa 05b. Esta tarefa ainda
-> precisa resolver `shouldExist()` -> `shouldExit()`.
+> Concluída em duas etapas:
+> - **2.2** (`isNextStateEqualsToCurrentScene` → `hasPendingStateChange`) foi
+>   executada dentro da tarefa 05b.
+> - **2.1** (`shouldExist()` → `shouldExit()`) executada aqui: renomeado em
+>   `IGameManager`, `GameManager`, no call site do `EngineManager`, nos mocks/fakes
+>   e testes. É breaking na API pública do core (coordenar bump `0.1.0`).
 
 ## Problema
 

--- a/.ai/task/04-const-and-logging.md
+++ b/.ai/task/04-const-and-logging.md
@@ -1,17 +1,18 @@
 # 04 — `const`-correctness + remover logging da biblioteca
 
-- **Status:** todo
+- **Status:** done ✅ (2026-07-04, branch `feature/cleanup-02-04-09-10`)
 - **Prioridade:** 🟡 Média
 - **Categoria:** Boas práticas
 - **Depende de:** 01, 02
-- **Bloqueia:** 05 (o Router será redesenhado; melhor entrar nele já com a
-  semântica de `const` correta)
 
-> Nota 2026-07-04: os mutadores antigos do `IRouter`
-> (`setNextState`, `goToNextScreen`) foram substituidos na tarefa 05b por
-> `requestState` e `commitStateChange`, ambos nao-`const`. Esta tarefa ainda
-> precisa remover o logging direto de `GameManager::cleanup()` e revisar qualquer
-> `const` remanescente fora da API do router.
+> Concluída em duas etapas:
+> - **`const`-correctness:** os mutadores antigos do `IRouter`
+>   (`setNextState`, `goToNextScreen`) foram substituídos na tarefa 05b por
+>   `requestState`/`commitStateChange`, ambos não-`const`. Sem `const` mentiroso
+>   remanescente (revisado `EngineManager`/`GameManager`).
+> - **Logging:** removido o `std::cout` de `GameManager::cleanup()` (e o
+>   `#include <iostream>` órfão). O hook `cleanup()` ficou vazio — abstração de
+>   log fica para o futuro, se necessário.
 
 ## Problema
 

--- a/.ai/task/09-code-hygiene.md
+++ b/.ai/task/09-code-hygiene.md
@@ -1,6 +1,13 @@
 # 09 — Higiene de código (includes, código morto, forward-declares)
 
-- **Status:** todo
+- **Status:** done ✅ (2026-07-04, branch `feature/cleanup-02-04-09-10`)
+
+> Executado: removido `EngineManager::input()` (morto — o loop chama
+> `gameManager->input()` direto) e o seu teste; removido `#include <iostream>`
+> órfão de `EngineManager.cpp`; removidas as linhas comentadas de `IScene.hpp`.
+> Os caminhos relativos `../../../` já haviam sido eliminados na 05a, e os
+> forward-declares redundantes do `IRouter` na 05b. Remover `input()` é breaking
+> na API pública do core (coordenar bump `0.1.0`).
 - **Prioridade:** 🟢 Baixa
 - **Categoria:** Boas práticas / limpeza
 - **Depende de:** 05 (fazer a limpeza depois da refatoração grande, para não

--- a/.ai/task/10-typed-states.md
+++ b/.ai/task/10-typed-states.md
@@ -1,6 +1,12 @@
 # 10 — Eliminar magic string e estados *stringly-typed*
 
-- **Status:** todo
+- **Status:** done ✅ (opção 1, 2026-07-04, branch `feature/cleanup-02-04-09-10`)
+
+> Executada a **opção 1** (mínima): a string mágica `"exit"` virou a constante
+> nomeada `cengine::routing::kExitStateCode` (`std::string_view`) em
+> `StateCodes.hpp`, usada em `GameManager::shouldExit()` e nos testes. As opções
+> 2/3 (sinal de saída tipado / `enum` em vez de `std::string` no `IState`) ficam
+> como evolução futura, se houver dor real com strings.
 - **Prioridade:** 🟢 Baixa
 - **Categoria:** Boas práticas / design
 - **Depende de:** 02 (nomes já corrigidos), 05 (desenho do Router estável)

--- a/core/include/cengine/core/EngineManager.hpp
+++ b/core/include/cengine/core/EngineManager.hpp
@@ -21,7 +21,6 @@ public:
     ~EngineManager() = default;
 
     void start();
-    void input() const;
     void cleanup() const;
 };
 

--- a/core/include/cengine/core/IGameManager.hpp
+++ b/core/include/cengine/core/IGameManager.hpp
@@ -12,7 +12,7 @@ public:
     virtual void onExit() = 0;
     virtual void cleanup() = 0;
 
-    [[nodiscard]] virtual bool shouldExist() const = 0;
+    [[nodiscard]] virtual bool shouldExit() const = 0;
 };
 
 } // namespace cengine::core

--- a/core/include/cengine/core/IScene.hpp
+++ b/core/include/cengine/core/IScene.hpp
@@ -3,14 +3,11 @@
 namespace cengine::core {
 
 class IScene {
-    // bool m_isEnterExecuted = false;
 public:
     IScene() = default;
     virtual ~IScene() = default;
 
     virtual void onEnter() = 0;
-    // virtual void onEnterExecuted() { m_isEnterExecuted = true; }
-    // [[nodiscard]] virtual bool isOnEnterExecuted() const { return m_isEnterExecuted; }
     virtual void onEnterExecuted() = 0;
     [[nodiscard]] virtual bool isOnEnterExecuted() const = 0;
 

--- a/core/src/EngineManager.cpp
+++ b/core/src/EngineManager.cpp
@@ -1,7 +1,5 @@
 #include <cengine/core/EngineManager.hpp>
 
-#include <iostream>
-
 namespace cengine::core {
 
 EngineManager::EngineManager(std::unique_ptr<IWindowManager> windowManager,
@@ -17,12 +15,6 @@ void EngineManager::start() {
 
     m_isRunning = true;
     run();
-}
-
-void EngineManager::input() const {
-    if (m_gameManager) {
-        m_gameManager->input();
-    }
 }
 
 void EngineManager::cleanup() const {
@@ -44,7 +36,7 @@ void EngineManager::run() {
         m_gameManager->render();
         m_gameManager->onExit();
 
-        m_isRunning = !m_gameManager->shouldExist();
+        m_isRunning = !m_gameManager->shouldExit();
     }
     cleanup();
 }

--- a/modules/routing/include/cengine/routing/GameManager.hpp
+++ b/modules/routing/include/cengine/routing/GameManager.hpp
@@ -17,7 +17,7 @@ public:
     void input() override;
     void onExit() override;
 
-    [[nodiscard]] bool shouldExist() const override;
+    [[nodiscard]] bool shouldExit() const override;
     void cleanup() override;
 };
 

--- a/modules/routing/include/cengine/routing/StateCodes.hpp
+++ b/modules/routing/include/cengine/routing/StateCodes.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string_view>
+
+namespace cengine::routing {
+
+// Código de estado especial que sinaliza o encerramento do jogo.
+// Usado no lugar da string literal "exit" espalhada pela lógica de controle.
+inline constexpr std::string_view kExitStateCode{"exit"};
+
+} // namespace cengine::routing

--- a/modules/routing/src/GameManager.cpp
+++ b/modules/routing/src/GameManager.cpp
@@ -2,11 +2,11 @@
 
 #include <cengine/core/IScene.hpp>
 
-#include <iostream>
 #include <utility>
 
 #include <cengine/routing/IState.hpp>
 #include <cengine/routing/IRouter.hpp>
+#include <cengine/routing/StateCodes.hpp>
 
 namespace cengine::routing {
 
@@ -39,13 +39,11 @@ void GameManager::onExit() {
     }
 }
 
-bool GameManager::shouldExist() const {
-    return m_routerService->currentState().getCode() == "exit";
+bool GameManager::shouldExit() const {
+    return m_routerService->currentState().getCode() == kExitStateCode;
 }
 
 void GameManager::cleanup() {
-    // std::println("");
-    std::cout << "TerminalGameManager: cleanup" << std::endl;
 }
 
 } // namespace cengine::routing

--- a/tests/core/EngineManagerTest.cpp
+++ b/tests/core/EngineManagerTest.cpp
@@ -53,8 +53,8 @@ TEST_F(EngineManagerTest, Start_InitializesWindowAndRunsLoop) {
     EXPECT_CALL(*m_capturedGameManager, render()).Times(1);
     EXPECT_CALL(*m_capturedGameManager, onExit()).Times(1);
 
-    // 3. shouldExist() é chamado para verificar se o loop deve continuar.
-    EXPECT_CALL(*m_capturedGameManager, shouldExist()).WillOnce(testing::Return(true));
+    // 3. shouldExit() é chamado para verificar se o loop deve continuar.
+    EXPECT_CALL(*m_capturedGameManager, shouldExit()).WillOnce(testing::Return(true));
 
     // 4. O loop termina e o método cleanup() é chamado.
     EXPECT_CALL(*m_capturedGameManager, cleanup()).Times(1);
@@ -62,13 +62,6 @@ TEST_F(EngineManagerTest, Start_InitializesWindowAndRunsLoop) {
 
     // Chamar o método start() da classe que estamos testando
     m_engineManager->start();
-}
-
-// Teste para o método input()
-TEST_F(EngineManagerTest, Input_CallsGameManagerInput) {
-    EXPECT_CALL(*m_capturedGameManager, input()).Times(1);
-
-    m_engineManager->input();
 }
 
 // Teste para o método cleanup()

--- a/tests/core/integration/FakeImplementations.hpp
+++ b/tests/core/integration/FakeImplementations.hpp
@@ -58,7 +58,7 @@ public:
         callLog.push_back("onExit");
     }
 
-    bool shouldExist() const override {
+    bool shouldExit() const override {
         // Retorna true para sair do loop após o número de iterações desejado.
         return runCount >= maxRuns;
     }

--- a/tests/mock/MockGameManager.hpp
+++ b/tests/mock/MockGameManager.hpp
@@ -13,5 +13,5 @@ public:
     MOCK_METHOD(void, onExit, (), (override));
     MOCK_METHOD(void, cleanup, (), (override));
 
-    MOCK_METHOD(bool, shouldExist, (), (const, override));
+    MOCK_METHOD(bool, shouldExit, (), (const, override));
 };

--- a/tests/routing/GameManagerTest.cpp
+++ b/tests/routing/GameManagerTest.cpp
@@ -6,6 +6,7 @@
 
 #include <cengine/core/IScene.hpp>
 #include <cengine/routing/GameManager.hpp>
+#include <cengine/routing/StateCodes.hpp>
 
 #include <mock/MockRouter.hpp>
 #include <mock/MockScene.hpp>
@@ -77,16 +78,16 @@ TEST_F(GameManagerTest, OnExit_WhenPendingStateChangeDoesNotExist_DoesNothing) {
     m_gameManager->onExit();
 }
 
-TEST_F(GameManagerTest, ShouldExist_WhenStateIsExit_ReturnsTrue) {
+TEST_F(GameManagerTest, ShouldExit_WhenStateIsExit_ReturnsTrue) {
     EXPECT_CALL(*m_mockRouter, currentState()).WillOnce(testing::ReturnRef(m_mockState));
-    EXPECT_CALL(m_mockState, getCode()).WillOnce(testing::Return("exit"));
+    EXPECT_CALL(m_mockState, getCode()).WillOnce(testing::Return(std::string(kExitStateCode)));
 
-    ASSERT_TRUE(m_gameManager->shouldExist());
+    ASSERT_TRUE(m_gameManager->shouldExit());
 }
 
-TEST_F(GameManagerTest, ShouldExist_WhenStateIsNotExit_ReturnsFalse) {
+TEST_F(GameManagerTest, ShouldExit_WhenStateIsNotExit_ReturnsFalse) {
     EXPECT_CALL(*m_mockRouter, currentState()).WillOnce(testing::ReturnRef(m_mockState));
     EXPECT_CALL(m_mockState, getCode()).WillOnce(testing::Return("main_menu"));
 
-    ASSERT_FALSE(m_gameManager->shouldExist());
+    ASSERT_FALSE(m_gameManager->shouldExit());
 }


### PR DESCRIPTION
## Objetivo

Reúne quatro tarefas de **qualidade de código** de baixo risco que compartilham
arquivos (`GameManager`, `EngineManager`, testes) — por isso vão juntas, para
não conflitarem entre si.

## Tarefas incluídas

| # | O quê |
|---|-------|
| **02** | `shouldExist` → `shouldExit` (o nome agora concorda com o retorno) |
| **04** | Remove `std::cout` de `GameManager::cleanup()` + `<iostream>` órfão |
| **09** | Remove código morto: `EngineManager::input()` (+ teste), includes órfãos, comentários em `IScene.hpp` |
| **10** | Magic string `"exit"` → constante `cengine::routing::kExitStateCode` (`StateCodes.hpp`) |

> Observação: a parte 2.2 da tarefa 02 (`isNextStateEqualsToCurrentScene` →
> `hasPendingStateChange`) e o `const` dos mutadores do router já haviam sido
> resolvidos na 05b; aqui fecham-se os pendentes.

## Verificação

- Build limpo (GCC 15.1.0 / MSYS2 UCRT64).
- **`ctest`: 27/27 verde** (caiu de 28 → 27 porque o teste do `input()` morto foi
  removido junto com o método).

## ⚠️ BREAKING CHANGE

`shouldExist` → `shouldExit` e a remoção de `EngineManager::input()` alteram a
**API pública do core**. Coordenar com o bump `0.1.0` (junto das mudanças das
05a/05b). O 8Puzzle puxa via FetchContent na tag `0.0.1` — não é afetado até
uma nova tag.

## Fora deste PR

- **06** (dangling de cena) — precisa de decisão de design (shared_ptr vs handle).
- **11** (documentação) — deve ser a última tarefa.
- **07/08** (build/CI) — vão em um PR separado (arquivos disjuntos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)