### PR TITLE
Build & ecossistema: presets portáveis, padrão C++23, CI com sanitizers (07/08)

### DIFF
--- a/.ai/build-and-test.md
+++ b/.ai/build-and-test.md
@@ -22,8 +22,12 @@ com segurança (rodar `ctest` a cada tarefa).
 
 ## Como reproduzir
 
-O working directory precisa ser a raiz do projeto **cengine**. O preset
-`msys2-mingw` exige o MSYS2 no PATH (por causa do `g++`/`ninja`).
+O working directory precisa ser a raiz do projeto **cengine**. Nesta máquina
+(MSYS2 UCRT64) o preset que funciona é o `msys2-mingw`, que vive em
+`CMakeUserPresets.json` (**não versionado** — ver tarefa 08). Os presets
+portáveis versionados (`debug`/`release`/`asan`, geradores Ninja) são para
+CI/outras máquinas; no MSYS2 o `ninja` embutido mastiga os paths nativos do
+compilador, então prefira o preset local `msys2-mingw` aqui.
 
 ```powershell
 # 1. Garantir o toolchain MSYS2 no PATH

--- a/.ai/task/07-cpp-standard.md
+++ b/.ai/task/07-cpp-standard.md
@@ -1,6 +1,13 @@
 # 07 — Alinhar padrão C++ entre cengine e consumidores
 
-- **Status:** todo
+- **Status:** done ✅ (2026-07-04, branch `feature/build-ecosystem-07-08`)
+
+> Executado: `target_compile_features(... PUBLIC cxx_std_23)` agora em
+> `cengine_core` (desde a 05a) **e** `cengine_routing` — o requisito de padrão
+> propaga automaticamente para quem linkar os targets. Documentado no README
+> (seção *Building*): CEngine exige C++23 e consumidores não precisam setar o
+> padrão na mão. Alinhar o 8Puzzle (C++20) fica para quando ele consumir a nova
+> tag.
 - **Prioridade:** 🟡 Média
 - **Categoria:** Ecossistema / compatibilidade
 - **Depende de:** — (independente do código; coordenar com 03, que já é breaking)

--- a/.ai/task/08-presets-and-ci.md
+++ b/.ai/task/08-presets-and-ci.md
@@ -1,6 +1,17 @@
 # 08 — Presets portáveis + CI (Debug + sanitizers)
 
-- **Status:** todo
+- **Status:** done ✅ (2026-07-04, branch `feature/build-ecosystem-07-08`)
+
+> Executado:
+> - `CMakePresets.json` agora tem presets **portáveis** (`debug`/`release`/`asan`,
+>   Ninja, sem paths hardcoded). O preset machine-specific `msys2-mingw` migrou
+>   para `CMakeUserPresets.json` (gitignorado).
+> - CI ganhou o job `build-and-test-linux-sanitizers` (Debug + ASan/UBSan).
+> - Documentado no README (seção *Building*).
+> - Ressalva conhecida: no MSYS2 desta máquina o `ninja` embutido mastiga paths
+>   nativos, então os presets Ninja são validados em CI/outras máquinas; local
+>   valida-se pelo `msys2-mingw`. Presets portáveis confirmados via
+>   `cmake --list-presets`.
 - **Prioridade:** 🟢 Baixa
 - **Categoria:** Ecossistema / build
 - **Depende de:** — (independente; porém ASan ajuda a validar a tarefa 06)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,27 @@ jobs:
       run: |
         cd build
         ctest --output-on-failure
+
+  build-and-test-linux-sanitizers:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout do Código
+      uses: actions/checkout@v4
+
+    - name: Configurar (Debug + ASan/UBSan)
+      run: >
+        cmake -S . -B build
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g"
+
+    - name: Buildar o Projeto
+      run: cmake --build build
+
+    - name: Rodar os Testes (com sanitizers)
+      run: |
+        cd build
+        ctest --output-on-failure
+      env:
+        ASAN_OPTIONS: detect_leaks=1
+        UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@
 
 # CLion
 *.idea
+
+# CMake presets específicos de máquina (compiladores/paths locais)
+CMakeUserPresets.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,34 +2,44 @@
     "version": 8,
     "configurePresets": [
         {
-            "name": "msys2-mingw",
-            "displayName": "GCC 15.1.0 x86_64-w64-mingw32 (ucrt64)",
-            "description": "Compila com GCC do MSYS2 UCRT64",
-            "generator": "MinGW Makefiles",
+            "name": "debug",
+            "displayName": "Debug (Ninja)",
+            "description": "Build de debug portável — detecta o compilador do PATH",
+            "generator": "Ninja",
             "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "installDir": "${sourceDir}/out/install/${presetName}",
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "C:/msys64/ucrt64/bin/gcc.exe",
-                "CMAKE_CXX_COMPILER": "C:/msys64/ucrt64/bin/g++.exe",
-                "CMAKE_MAKE_PROGRAM": "C:/msys64/ucrt64/bin/mingw32-make.exe"
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release (Ninja)",
+            "description": "Build de release portável — detecta o compilador do PATH",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "asan",
+            "displayName": "Debug + ASan/UBSan",
+            "description": "Debug com AddressSanitizer + UndefinedBehaviorSanitizer (GCC/Clang, ideal em Linux/CI)",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer -g"
             }
         }
     ],
     "buildPresets": [
-        {
-            "name": "msys2-mingw",
-            "configurePreset": "msys2-mingw",
-            "description": "Build com GCC 15.1.0 UCRT64",
-            "jobs": 8
-        }
+        { "name": "debug", "configurePreset": "debug", "jobs": 8 },
+        { "name": "release", "configurePreset": "release", "jobs": 8 },
+        { "name": "asan", "configurePreset": "asan", "jobs": 8 }
     ],
     "testPresets": [
-        {
-            "name": "msys2-mingw",
-            "configurePreset": "msys2-mingw",
-            "output": {
-                "outputOnFailure": true
-            }
-        }
+        { "name": "debug", "configurePreset": "debug", "output": { "outputOnFailure": true } },
+        { "name": "release", "configurePreset": "release", "output": { "outputOnFailure": true } },
+        { "name": "asan", "configurePreset": "asan", "output": { "outputOnFailure": true } }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 8,
+    "version": 4,
     "configurePresets": [
         {
             "name": "debug",

--- a/README.md
+++ b/README.md
@@ -14,6 +14,57 @@ Ideal for exploring concepts such as:
 
 Note: CEngine is part of a larger personal project and is under active experimentation.
 
+## Building
+
+CEngine uses CMake (>= 3.23) and requires a **C++23** compiler. The standard is
+propagated automatically via `target_compile_features(... PUBLIC cxx_std_23)`, so
+anything linking `cengine::core` / `cengine::routing` does not need to set the
+standard by hand.
+
+### Presets
+
+Portable presets (no machine-specific paths) live in `CMakePresets.json`:
+
+| Preset | Purpose |
+|--------|---------|
+| `debug` | Debug build (Ninja) |
+| `release` | Release build (Ninja) |
+| `asan` | Debug + AddressSanitizer/UBSan (best on Linux/CI) |
+
+```bash
+cmake --preset debug
+cmake --build --preset debug
+ctest --preset debug
+```
+
+Machine-specific presets (custom compiler paths, e.g. MSYS2/MinGW) belong in an
+untracked `CMakeUserPresets.json` (git-ignored).
+
+> **MSYS2/MinGW note:** the `debug`/`release`/`asan` presets use the Ninja
+> generator. MSYS2's bundled `ninja` runs commands through `/bin/sh`, which
+> mangles native (`C:\...`) compiler paths. On such setups, use a machine preset
+> with the `MinGW Makefiles` generator in your `CMakeUserPresets.json` instead
+> (or install a native Ninja).
+
+### Modules (opt-in)
+
+`cengine::core` (the game loop + ports) is always built. Optional modules are
+gated by CMake options:
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `CENGINE_BUILD_ROUTING` | `ON` | Build `cengine::routing` (scene/state routing) |
+| `CENGINE_BUILD_TESTS` | `ON` | Build the test suite |
+
+A consumer links only what it needs:
+
+```cmake
+target_link_libraries(my_game PRIVATE
+    cengine::core        # always
+    cengine::routing     # optional
+)
+```
+
 ## Working context (`.ai/`)
 
 The [`.ai/`](.ai/) folder is the starting point for understanding **what is being

--- a/modules/routing/CMakeLists.txt
+++ b/modules/routing/CMakeLists.txt
@@ -15,4 +15,7 @@ target_include_directories(cengine_routing PUBLIC
 
 target_link_libraries(cengine_routing PUBLIC cengine::core)
 
+# Propaga o requisito de padrão C++ para quem linkar o módulo (ver tarefa 07).
+target_compile_features(cengine_routing PUBLIC cxx_std_23)
+
 set_target_properties(cengine_routing PROPERTIES OUTPUT_NAME "cengine_routing")


### PR DESCRIPTION
## Objetivo

Tarefas de **build/ecossistema** — arquivos disjuntos do PR de limpeza de código
(#6), então os dois podem coexistir e mergear independentemente.

## Tarefas incluídas

### 07 — Propagação do padrão C++23
- `target_compile_features(... PUBLIC cxx_std_23)` agora também no
  `cengine_routing` (o `core` já tinha desde a 05a). O requisito de padrão
  **propaga automaticamente** para quem linka os targets — consumidores não
  precisam setar o padrão na mão (resolve o risco de mismatch C++20/23 silencioso).
- Documentado no README (nova seção **Building**).

### 08 — Presets portáveis + CI com sanitizers
- `CMakePresets.json` passou a ter presets **portáveis** (`debug`/`release`/`asan`
  com gerador Ninja, **sem paths hardcoded**).
- O preset machine-specific `msys2-mingw` (paths absolutos do MSYS2) migrou para
  `CMakeUserPresets.json`, agora **git-ignorado**.
- CI ganhou o job **`build-and-test-linux-sanitizers`** (Debug + AddressSanitizer
  + UBSan) — pega dangling/UB automaticamente (útil p/ a futura tarefa 06).

## Verificação

- `cmake --list-presets` reconhece os 4 presets (msys2-mingw via user presets +
  debug/release/asan versionados).
- Build + test local via preset `msys2-mingw` = **28/28**.
- **Ressalva:** os presets Ninja são para CI/máquinas com Ninja nativo. No MSYS2
  desta máquina o `ninja` embutido roda via `/bin/sh` e mastiga paths nativos do
  compilador — por isso local valida-se pelo `msys2-mingw` (nota registrada no
  README). O job de sanitizers roda em Linux no CI deste PR.

## Relação com os outros PRs

Disjunto do **#6** (limpeza de código). Sem overlap de arquivos — mergeiam em
qualquer ordem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)