### PR TITLE
Documentação: Doxygen nos headers públicos + seção Usage (task 11)

### DIFF
--- a/.ai/build-and-test.md
+++ b/.ai/build-and-test.md
@@ -76,24 +76,26 @@ Total Test time (real) = 0.20 sec
   clone de estado, comparação de estados.
 - `RouterInMemoryTest` — API enxuta do Router e delegação para o repositório.
 - `GameManagerTest` — ciclo `onEnter/render/input/onExit` e condição de saída.
+- `SceneLifetimeTest` (integração) — navegar → unload nas implementações reais,
+  garantindo que nenhuma referência de cena sobrevive ao unload (rede contra
+  *use-after-free*; ver [Tarefa 06](task/06-scene-lifetime.md)).
 - `EngineManagerTest` + `EngineManagerIntegrationTest` — loop principal validado
   por **call-log** (ordem exata das chamadas).
 
-## Observações ligadas ao plano de melhoria
+## Observações ligadas ao plano de melhoria (resolvidas)
 
-1. **O preset só funcionou por sorte de ambiente.** `CMakePresets.json` tem
-   caminhos absolutos hardcoded (`C:/msys64/ucrt64/...`) que batem com esta
-   máquina; numa máquina limpa falharia. → **[Tarefa 08](task/08-presets-and-ci.md)**.
+Snapshot de 2026-07-04, mantido como registro. Os três pontos já foram
+endereçados pelo plano:
 
-2. **Rede de segurança sólida.** Os 28 testes (incl. integração por call-log)
-   dão confiança para a cirurgia do `IRouter`. → **[Tarefa 05](task/05-redesign-irouter.md)**.
+1. ✅ **Preset por sorte de ambiente** (caminhos hardcoded no `CMakePresets.json`)
+   → resolvido na **[Tarefa 08](task/08-presets-and-ci.md)**: presets portáveis
+   versionados + máquina-específicos no `CMakeUserPresets.json` (git-ignored).
 
-3. **Os nomes dos próprios testes carregam os bugs de nomenclatura:**
-   - `GameManagerTest.ShouldExist_WhenStateIsNotExit_ReturnsFalse`
-   - `SceneRepositoryTest.IsNextStateEqualsToCurrentSceneReturnsTrueIfCodesDifferent`
-     (nome diz "Equals" mas retorna true quando os códigos **diferem**)
+2. ✅ **Rede de segurança** para a cirurgia do `IRouter` → o redesenho foi feito
+   na **[Tarefa 05b](task/05b-redesign-irouter.md)** com a suíte verde.
 
-   Ambos serão renomeados junto do código na **[Tarefa 02](task/02-fix-inverted-names.md)**.
+3. ✅ **Nomes invertidos nos testes** (`ShouldExist…`, `IsNextState…Equals…`)
+   → renomeados junto do código na **[Tarefa 02](task/02-fix-inverted-names.md)**.
 
 ## Protocolo para as tarefas do plano
 

--- a/.ai/task/11-documentation.md
+++ b/.ai/task/11-documentation.md
@@ -1,6 +1,6 @@
 # 11 — Documentação (Doxygen nos headers + uso no README)
 
-- **Status:** todo
+- **Status:** done
 - **Prioridade:** 🟢 Baixa
 - **Categoria:** Documentação
 - **Depende de:** todas as anteriores (documentar a API **já estabilizada**, para
@@ -45,9 +45,28 @@ pela documentação, sem ler a implementação.
 
 ## Critérios de aceite
 
-- [ ] Todos os headers públicos com doc-comment explicando contrato.
-- [ ] README com exemplo de consumo via FetchContent e montagem da engine.
-- [ ] Nenhum código comentado remanescente (coordenar com tarefa 09).
+- [x] Todos os headers públicos com doc-comment explicando contrato.
+- [x] README com exemplo de consumo via FetchContent e montagem da engine.
+- [x] Nenhum código comentado remanescente (coordenar com tarefa 09).
+
+## Implementação
+
+- **Doxygen** nos headers públicos de `core` (`IScene`, `IGameManager`,
+  `IWindowManager`, `EngineManager`) e `routing` (`IState`, `IRouter`,
+  `ISceneRepository`, `GameManager`, `RouterInMemory`, `SceneRepository`):
+  brief de classe + contrato/ordem de cada método (ciclo de vida da cena,
+  navegação em duas fases, `clone()` = Prototype, contratos de tempo de vida da
+  tarefa 06).
+- **README**: nova seção *Usage* com consumo via `FetchContent` (espelhando o
+  8Puzzle, com nota de que os targets modulares vivem no `main`) e um exemplo
+  mínimo de montagem (`SceneRepository → RouterInMemory → GameManager →
+  EngineManager`, registro de cenas por factory e navegação por estados).
+- **`.ai/build-and-test.md`**: atualizado — cobertura inclui `SceneLifetimeTest`,
+  observações do snapshot marcadas como resolvidas, link morto corrigido.
+- Os paths na descrição original desta tarefa (`include/engine/*.hpp`) eram
+  pré-05a; a doc foi aplicada na estrutura atual (`core/…`, `modules/routing/…`).
+- (Opcional) pasta `documentation/` e geração Doxygen no CMake/CI: **não feitos**
+  — ficam como melhoria futura, sem bloquear o critério de aceite.
 
 ## Riscos
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/mrmarmitt/cengine.git
   GIT_TAG        main   # pin a tagged release once available
 )
+
+# Consumers don't need cengine's own test suite. Turn it off before making the
+# dependency available — otherwise cengine fetches GoogleTest at configure time
+# (CENGINE_BUILD_TESTS defaults to ON), which is wasteful and fails offline.
+set(CENGINE_BUILD_TESTS OFF)
 FetchContent_MakeAvailable(cengine)
 
 add_executable(my_game src/main.cpp)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,78 @@ target_link_libraries(my_game PRIVATE
 )
 ```
 
+## Usage
+
+CEngine is consumed via CMake's `FetchContent` (this is how the sibling
+[8Puzzle](https://github.com/mrmarmitt/8puzzle) project uses it):
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  cengine
+  GIT_REPOSITORY https://github.com/mrmarmitt/cengine.git
+  GIT_TAG        main   # pin a tagged release once available
+)
+FetchContent_MakeAvailable(cengine)
+
+add_executable(my_game src/main.cpp)
+target_link_libraries(my_game PRIVATE
+    cengine::core        # game loop + ports (always)
+    cengine::routing     # scene/state routing (optional)
+)
+```
+
+> The `cengine::core` / `cengine::routing` targets require the modular layout on
+> `main`. The `0.0.1` tag predates it (single `cengine_lib` target).
+
+### Minimal assembly
+
+The engine is **graphics-agnostic**: you implement the ports (window + scenes)
+and the engine drives the loop. A minimal game wires up a window manager, a
+router over a scene repository, and hands both to the `EngineManager`:
+
+```cpp
+#include <memory>
+#include <cengine/core/EngineManager.hpp>
+#include <cengine/routing/GameManager.hpp>
+#include <cengine/routing/RouterInMemory.hpp>
+#include <cengine/routing/SceneRepository.hpp>
+
+using namespace cengine;
+
+int main() {
+    // 1. Repository seeded with the initial state (you provide MyState : IState).
+    auto repository = std::make_shared<routing::SceneRepository>(
+        std::make_unique<MyState>("main_menu"));
+
+    // 2. Register a scene factory per state code (lazy instantiation).
+    //    You provide MenuScene / GameplayScene : cengine::core::IScene.
+    repository->registerFactory("main_menu", [] { return std::make_unique<MenuScene>(); });
+    repository->registerFactory("gameplay",  [] { return std::make_unique<GameplayScene>(); });
+
+    // 3. Router over the repository, exposed to the game as an IGameManager.
+    auto router      = std::make_shared<routing::RouterInMemory>(repository);
+    auto gameManager = std::make_unique<routing::GameManager>(router);
+
+    // 4. Run the loop (you provide MyWindowManager : cengine::core::IWindowManager).
+    core::EngineManager engine{
+        std::make_unique<MyWindowManager>(),
+        std::move(gameManager)
+    };
+    engine.start(); // blocks until a scene routes to the exit state
+    return 0;
+}
+```
+
+To navigate, a scene calls `router->requestState(std::make_unique<MyState>("gameplay"))`;
+the switch is committed at the end of the frame (`onExit`). Routing to the
+`cengine::routing::kExitStateCode` state stops the loop.
+
+The public headers carry Doxygen comments describing each contract — start from
+[`IScene`](core/include/cengine/core/IScene.hpp) and
+[`IGameManager`](core/include/cengine/core/IGameManager.hpp).
+
 ## Working context (`.ai/`)
 
 The [`.ai/`](.ai/) folder is the starting point for understanding **what is being

--- a/core/include/cengine/core/EngineManager.hpp
+++ b/core/include/cengine/core/EngineManager.hpp
@@ -7,6 +7,26 @@
 
 namespace cengine::core {
 
+/**
+ * @brief O coração da engine: o game loop.
+ *
+ * É a única classe concreta do `core`. Recebe por injeção de dependência um
+ * `IWindowManager` (a plataforma gráfica) e um `IGameManager` (as regras/telas
+ * do jogo), assumindo posse de ambos, e roda o loop principal até o jogo pedir
+ * para sair.
+ *
+ * Cada iteração executa: `window.update()` → `game.onEnter()` → `game.input()`
+ * → `game.render()` → `game.onExit()`, e para quando `game.shouldExit()` retorna
+ * true — encerrando com `cleanup()`.
+ *
+ * @code
+ * cengine::core::EngineManager engine{
+ *     std::make_unique<MyWindowManager>(),
+ *     std::make_unique<MyGameManager>()
+ * };
+ * engine.start(); // bloqueia até o jogo pedir para sair
+ * @endcode
+ */
 class EngineManager {
     void run();
     std::unique_ptr<IWindowManager> m_windowManager;
@@ -14,13 +34,20 @@ class EngineManager {
     bool m_isRunning;
 
 public:
+    /**
+     * @param windowManager plataforma gráfica (posse transferida à engine).
+     * @param gameManager   regras/telas do jogo (posse transferida à engine).
+     */
     EngineManager(
         std::unique_ptr<IWindowManager> windowManager,
         std::unique_ptr<IGameManager> gameManager);
 
     ~EngineManager() = default;
 
+    /// Inicializa a janela e entra no game loop. Bloqueia até `shouldExit()`.
     void start();
+
+    /// Libera recursos do jogo e da janela. Invocado ao final de `start()`.
     void cleanup() const;
 };
 

--- a/core/include/cengine/core/IGameManager.hpp
+++ b/core/include/cengine/core/IGameManager.hpp
@@ -2,16 +2,37 @@
 
 namespace cengine::core {
 
+/**
+ * @brief Ponte entre o game loop da engine e as regras/telas do jogo.
+ *
+ * O `EngineManager` conhece apenas esta interface; toda a lógica de "qual cena
+ * está ativa e o que ela faz" fica do lado do jogo (por exemplo, na
+ * implementação `cengine::routing::GameManager`, que delega para o roteador).
+ *
+ * Os métodos abaixo são chamados a cada iteração do loop, na ordem:
+ * `onEnter()` → `input()` → `render()` → `onExit()`, e por fim `shouldExit()`
+ * decide se o loop continua. `cleanup()` roda uma vez, ao encerrar.
+ */
 class IGameManager {
 public:
     virtual ~IGameManager() = default;
 
+    /// Ativa/entra na cena atual (idempotente por ativação — ver IScene).
     virtual void onEnter() = 0;
+
+    /// Renderiza a cena atual.
     virtual void render() = 0;
+
+    /// Processa a entrada do usuário na cena atual.
     virtual void input() = 0;
+
+    /// Trata a saída da cena atual e efetiva uma eventual troca de estado.
     virtual void onExit() = 0;
+
+    /// Libera recursos do jogo. Chamado uma vez, no encerramento da engine.
     virtual void cleanup() = 0;
 
+    /// @return true quando o jogo pediu para encerrar; para o game loop.
     [[nodiscard]] virtual bool shouldExit() const = 0;
 };
 

--- a/core/include/cengine/core/IScene.hpp
+++ b/core/include/cengine/core/IScene.hpp
@@ -2,17 +2,48 @@
 
 namespace cengine::core {
 
+/**
+ * @brief Uma tela/estado renderizável do jogo (menu, gameplay, game over...).
+ *
+ * O jogo implementa esta interface; a engine apenas orquestra o ciclo de vida.
+ * A engine é agnóstica de biblioteca gráfica: o que `draw()`/`input()` fazem por
+ * baixo (SDL, Raylib, terminal...) é decisão do jogo.
+ *
+ * ## Ciclo de vida (por iteração do game loop)
+ * A cada volta do loop o gerenciador de jogo chama, nesta ordem:
+ * `onEnter()` (só na primeira vez em que a cena é ativada) → `input()` →
+ * `draw()`. Ao trocar de cena, a cena que sai recebe `onExit()`.
+ *
+ * O par `onEnterExecuted()`/`isOnEnterExecuted()` existe para garantir que
+ * `onEnter()` rode **uma única vez** por ativação, mesmo que a cena permaneça
+ * ativa por muitas iterações.
+ *
+ * @note Contrato de tempo de vida: referências a uma cena obtidas via
+ *       `cengine::routing::IRouter::currentScene()` só valem até a próxima
+ *       navegação. Nunca retenha uma `IScene&` através de uma troca de estado.
+ */
 class IScene {
 public:
     IScene() = default;
     virtual ~IScene() = default;
 
+    /// Inicialização única da cena (carregar recursos, montar objetos).
+    /// Chamado uma vez por ativação, antes do primeiro `input()`/`draw()`.
     virtual void onEnter() = 0;
+
+    /// Marca `onEnter()` como já executado (chamado pela engine após `onEnter()`).
     virtual void onEnterExecuted() = 0;
+
+    /// @return true se `onEnter()` já rodou nesta ativação (evita reexecução).
     [[nodiscard]] virtual bool isOnEnterExecuted() const = 0;
 
+    /// Desenha o quadro atual. Chamado toda iteração enquanto a cena está ativa.
     virtual void draw() = 0;
+
+    /// Processa entrada do usuário. Chamado toda iteração, antes de `draw()`.
     virtual void input() = 0;
+
+    /// Finalização da cena (liberar recursos). Chamado ao sair/trocar de cena.
     virtual void onExit() = 0;
 };
 

--- a/core/include/cengine/core/IWindowManager.hpp
+++ b/core/include/cengine/core/IWindowManager.hpp
@@ -2,12 +2,28 @@
 
 namespace cengine::core {
 
+/**
+ * @brief Abstrai a janela/plataforma gráfica sobre a qual o jogo roda.
+ *
+ * É o ponto de extensão que mantém a engine **agnóstica de biblioteca gráfica**:
+ * o jogo fornece uma implementação (SDL, Raylib, GLFW, terminal...) e a engine
+ * só a aciona pelo contrato abaixo.
+ *
+ * Chamadas pelo `EngineManager`: `init()` uma vez em `start()`, `update()` toda
+ * iteração do loop (processar eventos da janela, swap de buffers), e `cleanup()`
+ * uma vez ao encerrar.
+ */
 class IWindowManager {
 public:
     virtual ~IWindowManager() = default;
 
+    /// Cria/inicializa a janela e o contexto gráfico. Chamado uma vez.
     virtual void init() = 0;
+
+    /// Atualiza a janela por iteração (eventos de SO, apresentação do quadro).
     virtual void update() = 0;
+
+    /// Destrói a janela e libera recursos gráficos. Chamado uma vez, ao sair.
     virtual void cleanup() = 0;
 };
 

--- a/modules/routing/include/cengine/routing/GameManager.hpp
+++ b/modules/routing/include/cengine/routing/GameManager.hpp
@@ -7,6 +7,14 @@
 
 namespace cengine::routing {
 
+/**
+ * @brief Implementação de `core::IGameManager` baseada em roteamento de cenas.
+ *
+ * Liga o game loop da engine (que só conhece `IGameManager`) ao `IRouter`:
+ * cada callback do loop é delegado à cena atual obtida do roteador, e `onExit()`
+ * efetiva uma eventual troca de estado pendente. `shouldExit()` compara o estado
+ * atual com `kExitStateCode`.
+ */
 class GameManager : public core::IGameManager {
     std::shared_ptr<IRouter> m_routerService;
 public:

--- a/modules/routing/include/cengine/routing/IRouter.hpp
+++ b/modules/routing/include/cengine/routing/IRouter.hpp
@@ -9,14 +9,31 @@ namespace cengine::routing {
 
 class IState;
 
+/**
+ * @brief Orquestra a navegação entre estados/telas do jogo.
+ *
+ * O roteamento é um **módulo opcional** (`cengine::routing`), fora do núcleo da
+ * engine: um jogo pode usá-lo ou fornecer sua própria navegação. Ver
+ * ADR 0001 em `.ai/decisions/`.
+ *
+ * A troca de estado é em duas fases (para não trocar de cena no meio de uma
+ * iteração do loop): `requestState()` agenda o próximo estado e
+ * `commitStateChange()` o efetiva — normalmente ao final de `onExit()`.
+ */
 class IRouter {
 public:
     virtual ~IRouter() = default;
 
+    /// Agenda a transição para @p state (efetivada depois, em commitStateChange).
     virtual void requestState(std::unique_ptr<IState> state) = 0;
+
+    /// @return true se há uma troca de estado agendada e ainda não efetivada.
     [[nodiscard]] virtual bool hasPendingStateChange() const = 0;
+
+    /// Efetiva a troca agendada: descarrega a cena atual e promove a próxima.
     virtual void commitStateChange() = 0;
 
+    /// @return o estado atualmente ativo.
     [[nodiscard]] virtual const IState& currentState() const = 0;
 
     // Contrato de tempo de vida: a referência retornada é válida apenas até a

--- a/modules/routing/include/cengine/routing/ISceneRepository.hpp
+++ b/modules/routing/include/cengine/routing/ISceneRepository.hpp
@@ -8,22 +8,45 @@
 
 namespace cengine::routing {
 
+/**
+ * @brief Guarda as cenas (instanciadas *lazy* via factory) e o par de estados
+ *        atual/próximo que sustenta a navegação em duas fases do `IRouter`.
+ *
+ * Cenas são criadas sob demanda a partir de factories registradas por código de
+ * estado e podem ser descarregadas para liberar memória. É a peça que o
+ * `RouterInMemory` usa por baixo.
+ */
 class ISceneRepository {
 public:
     virtual ~ISceneRepository() = default;
 
+    /// Registra a factory que cria a cena do estado @p name (instanciação lazy).
     virtual void registerFactory(const std::string& name, std::function<std::unique_ptr<core::IScene>()> factory) = 0;
+
+    /// @return o estado atualmente ativo.
     virtual IState& getCurrentStateGame() const = 0;
+
+    /// @return o próximo estado agendado (igual ao atual se nada pendente).
     virtual IState& getNextStateGame() const = 0;
+
+    /// Promove o próximo estado a atual (efetiva a troca).
     virtual void persisteCurrentState() = 0;
+
+    /// Define o próximo estado agendado.
     virtual void persistNextState(std::unique_ptr<IState> state) = 0;
     // Contrato de tempo de vida: a referência retornada aponta para dentro do
     // mapa interno de cenas e é invalidada por unloadScene(name)/unloadAll().
     // NÃO retenha a referência através de um desses unloads. Ver
     // .ai/task/06-scene-lifetime.md.
     virtual core::IScene& getScene(const std::string& name) = 0;
+
+    /// Descarrega a cena @p name (será recriada via factory se pedida de novo).
     virtual void unloadScene(const std::string& name) = 0;
+
+    /// Descarrega todas as cenas instanciadas.
     virtual void unloadAll() = 0;
+
+    /// @return true se o próximo estado difere do atual (troca pendente).
     virtual bool hasPendingStateChange() const = 0;
 };
 

--- a/modules/routing/include/cengine/routing/IState.hpp
+++ b/modules/routing/include/cengine/routing/IState.hpp
@@ -5,12 +5,29 @@
 
 namespace cengine::routing {
 
+/**
+ * @brief Um estado do jogo, identificado por um código, ao qual corresponde uma
+ *        cena (`IScene`).
+ *
+ * O `getCode()` é a chave usada pelo roteador/repositório para localizar a cena
+ * do estado (ex.: `"main_menu"`, `"gameplay"`, `cengine::routing::kExitStateCode`).
+ * O jogo define seus próprios estados implementando esta interface.
+ *
+ * `clone()` segue o padrão **Prototype**: o repositório guarda cópias
+ * independentes do estado atual e do próximo, sem acoplar-se ao tipo concreto —
+ * por isso o estado deve saber se duplicar.
+ */
 class IState {
 public:
     virtual ~IState() = default;
 
+    /// Código único do estado; chave da cena correspondente. Ex.: "gameplay".
     [[nodiscard]] virtual std::string getCode() const = 0;
+
+    /// Nome legível do estado (para logs/depuração).
     [[nodiscard]] virtual std::string getName() const = 0;
+
+    /// Cria uma cópia independente deste estado (padrão Prototype).
     [[nodiscard]] virtual std::unique_ptr<IState> clone() const = 0;
 };
 

--- a/modules/routing/include/cengine/routing/RouterInMemory.hpp
+++ b/modules/routing/include/cengine/routing/RouterInMemory.hpp
@@ -8,6 +8,13 @@
 
 namespace cengine::routing {
 
+/**
+ * @brief `IRouter` em memória, apoiado em um `ISceneRepository`.
+ *
+ * Delega o estado e as cenas ao repositório; `commitStateChange()` descarrega a
+ * cena do estado que sai e promove o próximo. `currentScene()` resolve a cena do
+ * estado atual sob demanda (instanciação lazy pelo repositório).
+ */
 class RouterInMemory final : public IRouter {
     std::shared_ptr<ISceneRepository> m_sceneRepository;
 

--- a/modules/routing/include/cengine/routing/SceneRepository.hpp
+++ b/modules/routing/include/cengine/routing/SceneRepository.hpp
@@ -11,6 +11,14 @@
 
 namespace cengine::routing {
 
+/**
+ * @brief `ISceneRepository` em memória: mapa de factories + cache de cenas
+ *        instanciadas, com o par de estados atual/próximo.
+ *
+ * `getScene()` instancia a cena via factory na primeira vez e a mantém em cache
+ * até um `unloadScene`/`unloadAll`. Os estados são guardados como cópias
+ * independentes (via `IState::clone()`), sustentando a navegação em duas fases.
+ */
 class SceneRepository final : public ISceneRepository {
     std::unordered_map<std::string, std::unique_ptr<core::IScene>> m_scenes;
     std::unordered_map<std::string, std::function<std::unique_ptr<core::IScene>()>> m_factories;


### PR DESCRIPTION
Fecha a **task 11** — a última do plano `.ai/task`. Documenta a API **já estabilizada** (por isso ficou por último, depois de 05/06 fixarem a interface do routing).

## Mudanças
- **Doxygen nos headers públicos**:
  - `core`: `IScene`, `IGameManager`, `IWindowManager`, `EngineManager`.
  - `routing`: `IState`, `IRouter`, `ISceneRepository`, `GameManager`, `RouterInMemory`, `SceneRepository`.
  - Brief de classe + contrato/ordem de cada método: ciclo de vida da cena (`onEnter → input → draw → onExit`), navegação em duas fases (`requestState`/`commitStateChange`), `clone()` como padrão Prototype, e os contratos de tempo de vida introduzidos na task 06.
- **README → seção `Usage`**: consumo via `FetchContent` (espelhando o 8Puzzle) + exemplo mínimo de montagem (`SceneRepository → RouterInMemory → GameManager → EngineManager`, registro de cenas por factory e navegação por estados). Nota de que os targets `cengine::core`/`cengine::routing` vivem no `main` (a tag `0.0.1` é pré-modularização).
- **`.ai/build-and-test.md`**: cobertura passa a listar `SceneLifetimeTest`; observações do snapshot marcadas como resolvidas; corrigido link morto (`05-redesign-irouter.md` → `05b`).

## Verificação
- Só documentação — nenhuma mudança de comportamento.
- Build `msys2-mingw`: **28/28**.

Com esta, **todas as tarefas do plano `.ai/task` estão concluídas** (06 e 11 eram as pendentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)