### PR TITLE
Release 0.1.0: CHANGELOG + bump de versão

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+All notable changes to CEngine are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-06
+
+First release after the architecture overhaul guided by the improvement plan in
+[`.ai/`](.ai/) (see [ADR 0001](.ai/decisions/0001-modular-core-vs-modules.md)).
+The engine is now a **graphics-agnostic game loop + ports**, with scene/state
+routing as an **opt-in module**.
+
+> **Breaking release.** The library layout, target names, namespaces, include
+> paths and parts of the public API changed. Consumers of `0.0.1` must update —
+> see _Migrating from 0.0.1_ below.
+
+### Added
+
+- **Modular multi-target layout**: `cengine::core` (game loop + ports) and the
+  optional `cengine::routing` (scene/state routing) module. Consumers link only
+  what they need.
+- **CMake options** to gate the build: `CENGINE_BUILD_ROUTING` (default `ON`) and
+  `CENGINE_BUILD_TESTS` (default `ON`). The core builds standalone without routing.
+- **C++23 requirement propagated** via `target_compile_features(... PUBLIC
+  cxx_std_23)` — anything linking the targets inherits the standard.
+- **Portable CMake presets** (`debug`, `release`, `asan`) in `CMakePresets.json`;
+  machine-specific presets now live in a git-ignored `CMakeUserPresets.json`.
+- **CI sanitizer job** (Linux, AddressSanitizer + UndefinedBehaviorSanitizer).
+- **`StateCodes.hpp`** with `cengine::routing::kExitStateCode`, replacing the
+  `"exit"` magic string.
+- **Scene-lifetime regression test** (`SceneLifetimeTest`) exercising
+  navigate → unload against the real implementations, meant to run under ASan.
+- **Documentation**: Doxygen comments on all public headers; `Building` and
+  `Usage` sections in the README (FetchContent consumption + minimal assembly).
+- **`.ai/` working context**: improvement plan, ADR 0001, and verified
+  build & test notes.
+
+### Changed
+
+- **Namespaces**: public types now live under `cengine::core` and
+  `cengine::routing`.
+- **Include paths**: headers are included as `<cengine/core/...>` and
+  `<cengine/routing/...>`.
+- **`IRouter` redesigned** to a leaner two-phase navigation contract
+  (`requestState` / `hasPendingStateChange` / `commitStateChange` /
+  `currentState` / `currentScene`).
+- **`IState`** now belongs to the `cengine::routing` module (it is a routing
+  concept, not a core one).
+
+### Removed
+
+- **`EngineManager::input()`** removed from the public API (dead code; the loop
+  drives input through the game manager).
+
+### Fixed
+
+- **Scene-lifetime dangling window** in `GameManager::onExit()`: the scene
+  reference could outlive the `commitStateChange()` that unloads it. The
+  reference is now scoped so it cannot survive the unload, the lifetime contract
+  is documented on `IRouter::currentScene()` / `ISceneRepository::getScene()`,
+  and a regression test guards it.
+- **Inverted names**: `IGameManager::shouldExist()` → `shouldExit()`, plus the
+  correspondingly misleading test names.
+- **Logging removed from the library** (no more `std::cout` in `GameManager`).
+- **Dead code and stray includes** removed across core and routing.
+- **CMake preset schema** lowered from `version: 8` (needs CMake ≥ 3.28) to
+  `version: 4`, matching the declared `cmake_minimum_required(VERSION 3.23)`.
+
+### Migrating from 0.0.1
+
+- Replace the single `cengine_lib` link with the modular targets:
+  ```cmake
+  target_link_libraries(my_game PRIVATE
+      cengine::core        # game loop + ports (always)
+      cengine::routing     # scene/state routing (optional)
+  )
+  ```
+- When pulling CEngine via `FetchContent`, disable its test suite before
+  `FetchContent_MakeAvailable(cengine)` to avoid fetching GoogleTest at configure
+  time: `set(CENGINE_BUILD_TESTS OFF)`.
+- Update includes to the `<cengine/core/...>` / `<cengine/routing/...>` layout
+  and qualify types with the `cengine::core` / `cengine::routing` namespaces.
+- Rename `shouldExist()` to `shouldExit()` in your `IGameManager` implementations.
+- Replace the `"exit"` state string with `cengine::routing::kExitStateCode`.
+
+## [0.0.1] - Initial
+
+- Initial single-target (`cengine_lib`) engine: game loop, scene/state
+  management, and in-memory router.
+
+[0.1.0]: https://github.com/mrmarmitt/cengine/compare/0.0.1...0.1.0
+[0.0.1]: https://github.com/mrmarmitt/cengine/releases/tag/0.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(cengine VERSION 0.0.1 LANGUAGES CXX)
+project(cengine VERSION 0.1.0 LANGUAGES CXX)
 
 # Define padrão do projeto
 set(CMAKE_CXX_STANDARD 23)


### PR DESCRIPTION
Prepara a release **0.1.0** — a primeira depois da reforma arquitetural do plano `.ai/task` (todas as 11 tarefas concluídas).

## Conteúdo
- **`CHANGELOG.md`** (formato [Keep a Changelog](https://keepachangelog.com/)) com `Added` / `Changed` / `Removed` / `Fixed` desde `0.0.1` e um **guia de migração**.
- **Bump** `project(cengine VERSION 0.0.1 → 0.1.0)`.

## Por que 0.1.0 (breaking, SemVer)
Desde a `0.0.1` mudaram: layout modular multi-target (`cengine::core` + `cengine::routing`, antes `cengine_lib`), namespaces, include paths, redesenho do `IRouter`, rename `shouldExist`→`shouldExit`, remoção de `EngineManager::input()`. O guia de migração no CHANGELOG cobre cada ponto.

## Próximo passo (após merge)
Criar a tag anotada `0.1.0` apontando para o merge commit na `main` (o tag precisa conter este CHANGELOG). Faço isso assim que você mergear.

Verificação: `cmake` reconhece `CMAKE_PROJECT_VERSION=0.1.0`; suíte 28/28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)