### PR TITLE
refactor(core)!: contabilidade de ativacao sai da IScene (task 12)

### DIFF
--- a/.ai/task/12-scene-activation-bookkeeping.md
+++ b/.ai/task/12-scene-activation-bookkeeping.md
@@ -1,0 +1,131 @@
+# 12 — Tirar a contabilidade de ativação (`onEnter`) da `IScene`
+
+- **Status:** done ✅ (opção 1, 2026-07-07, branch `feature/12-scene-activation-bookkeeping`)
+- **Prioridade:** 🟡 Média
+- **Categoria:** Arquitetura / design de API
+- **Depende de:** 05b (Router estável), 06 (lifetime das cenas definido)
+- **Relacionada:** 13 (redesenho Router/Repository — executar 12 antes, é a
+  cirurgia menor)
+- **Breaking:** sim — coordenar com bump de versão (0.2.0) junto da tarefa 13.
+
+## Problema
+
+A porta `IScene` (`core/include/cengine/core/IScene.hpp`) tem 6 métodos, mas
+apenas 4 pertencem à cena (`onEnter`, `input`, `draw`, `onExit`). O par
+
+```cpp
+virtual void onEnterExecuted() = 0;
+[[nodiscard]] virtual bool isOnEnterExecuted() const = 0;
+```
+
+é **contabilidade da engine vazando para o implementador**: serve só para o
+`GameManager::onEnter()` saber se `onEnter()` já rodou nesta ativação. Efeitos:
+
+1. **Boilerplate obrigatório em todo jogo.** Cada cena precisa carregar um
+   boolean e implementar os dois métodos corretamente (no 8Puzzle, toda a
+   hierarquia `TerminalScene` paga esse custo).
+2. **Erro silencioso.** Se o implementador esquecer de resetar/retornar o flag
+   certo, `onEnter()` roda toda iteração (ou nunca) — sem erro de compilação.
+3. **Acoplamento escondido com a política de unload.** O flag só "reseta"
+   porque `commitStateChange()` **destrói** a cena que sai. Se um dia houver
+   keep-alive de cenas (ver pendência da tarefa 13), `isOnEnterExecuted()`
+   permanece `true` e `onEnter()` nunca mais roda ao voltar para a cena — bug
+   garantido por construção.
+
+Quem sabe "a cena atual já foi ativada neste ciclo?" é o **orquestrador**
+(`GameManager`), não a cena. Tell, don't ask.
+
+## Objetivo
+
+`IScene` com 4 métodos coesos; a garantia "onEnter roda exatamente uma vez por
+ativação" passa a ser responsabilidade da engine, invisível para o jogo.
+
+## Opções (decidir na tarefa)
+
+1. **Engine-side tracking no `GameManager` (recomendada).** O `GameManager`
+   guarda o código do estado cuja cena já recebeu `onEnter`:
+
+   ```cpp
+   class GameManager : public core::IGameManager {
+       std::shared_ptr<IRouter> m_routerService;
+       std::string m_enteredStateCode; // vazio = nenhuma cena ativada
+   public:
+       void onEnter() override {
+           const auto code = m_routerService->currentState().getCode();
+           if (code != m_enteredStateCode) {
+               m_routerService->currentScene().onEnter();
+               m_enteredStateCode = code;
+           }
+       }
+       void onExit() override {
+           // ... fluxo atual ...
+           m_routerService->commitStateChange();
+           m_enteredStateCode.clear(); // próxima cena será ativada no próximo frame
+       }
+   };
+   ```
+
+   `IScene` perde os dois métodos; nenhum estado novo na engine além de uma
+   string no `GameManager`. Funciona com qualquer política de unload futura,
+   porque o reset acontece **no commit**, não na destruição da cena.
+
+2. **Classe base `SceneBase` com o flag.** Mantém a interface como está e
+   oferece uma base que implementa o par de métodos. Menos breaking, mas não
+   resolve o problema — a interface continua com 6 métodos e o contrato
+   continua violável por quem não herdar da base.
+
+3. **Ativação no provisionamento (repository chama `onEnter` ao instanciar).**
+   Elegante à primeira vista (cena "nasce ativada"), mas mistura provisionamento
+   com timing de ciclo de vida: `onEnter` rodaria no meio de `commitStateChange`
+   ou de um `getScene()` qualquer, fora da fase `onEnter` do loop. Descartada.
+
+> Recomendação: opção 1. A opção 2 só se quisermos uma migração em duas etapas
+> (base agora, remoção dos métodos depois) — para um projeto de estudo com um
+> único consumidor conhecido, não compensa.
+
+## Passos
+
+1. Remover `onEnterExecuted()`/`isOnEnterExecuted()` de `IScene`.
+2. Implementar o tracking no `GameManager` (opção 1), resetando no commit.
+3. Atualizar `MockScene` e os testes de `GameManagerTest` que cobrem
+   `OnEnter_WhenSceneNotInitialized_*` / `OnEnter_WhenSceneAlreadyInitialized_*`
+   — a expectativa passa a ser sobre o número de chamadas a `scene.onEnter()`,
+   não sobre o flag.
+4. Adicionar teste novo: após uma navegação (commit), a cena do novo estado
+   recebe `onEnter()` no frame seguinte (garante o reset).
+5. Adicionar teste de regressão para o acoplamento escondido: navegar A→B→A
+   deve reativar A (hoje passa por acidente via unload; o teste protege o
+   comportamento quando a política de unload mudar).
+6. Atualizar o Doxygen de `IScene` e `IGameManager` (o contrato "uma vez por
+   ativação" passa a ser garantido pela engine).
+
+## Critérios de aceite
+
+- [x] `IScene` com exatamente 4 métodos: `onEnter`, `input`, `draw`, `onExit`.
+- [x] Nenhuma menção a `onEnterExecuted` no repositório (código, mocks, docs).
+- [x] Teste cobrindo "onEnter roda 1x por ativação" e "reativação após A→B→A".
+- [x] Suíte verde.
+
+## Resultado da execução
+
+- `IScene` reduzida a 4 métodos; Doxygen atualizado (a garantia "1x por
+  ativação" é do orquestrador).
+- `GameManager` ganhou `m_enteredStateCode` (código do estado ativado),
+  comparado em `onEnter()` e limpo após `commitStateChange()` em `onExit()`.
+- `MockScene` e `TrackedScene` (SceneLifetimeTest) enxugados; `TrackedScene`
+  agora conta ativações (`onEnterCount`).
+- Testes novos: `OnEnter_SameStateOnNextIterations_DoesNotReenter`,
+  `OnEnter_AfterCommittedNavigation_ReentersEvenWithSameStateCode` (unidade) e
+  `SceneLifetimeTest.NavigatingBackReactivatesScene` (integração A→B→A).
+- Suíte: **30/30 testes passaram** (`ctest --preset msys2-mingw`).
+
+## Riscos
+
+Baixo. A mudança é localizada (`IScene`, `GameManager`, mocks e testes). O
+único consumidor conhecido (8Puzzle) precisa remover o boilerplate das cenas —
+simplificação, não reescrita.
+
+## Pendências fora do escopo
+
+- Atualizar o 8Puzzle: remover flag/métodos das cenas de terminal
+  (`TerminalScene` e derivadas) ao consumir a versão 0.2.0.

--- a/.ai/task/13-router-repository-responsibilities.md
+++ b/.ai/task/13-router-repository-responsibilities.md
@@ -1,0 +1,149 @@
+# 13 — Separar responsabilidades: Router (navegação) × Repository (cenas)
+
+- **Status:** todo
+- **Prioridade:** 🔴 Alta (arquitetural)
+- **Categoria:** Arquitetura
+- **Depende de:** 05b (API do Router estável), 12 (IScene enxuta — fazer antes,
+  reduz a superfície desta cirurgia)
+- **Decisão de referência:** [ADR 0001](../decisions/0001-modular-core-vs-modules.md)
+- **Breaking:** sim — coordenar com bump de versão (0.2.0) junto da tarefa 12.
+
+## Problema
+
+Hoje `RouterInMemory` e `SceneRepository` são **a mesma abstração dividida em
+duas**:
+
+1. **Pass-through puro.** Todo método de `RouterInMemory` delega uma única
+   chamada ao `ISceneRepository` (`RouterInMemory.cpp`) — o router não tem
+   estado nem decisão própria além do unload no commit.
+2. **Repository com dois papéis.** `ISceneRepository` acumula (a) cache de
+   cenas com factories lazy e (b) o par de estados atual/próximo da navegação
+   em duas fases — inclusive expõe `hasPendingStateChange()`, duplicando a API
+   do router uma camada abaixo.
+3. **Sintomas na borda.** Nomes como `persisteCurrentState()` (semântica
+   invertida: promove o *próximo* a atual) e `getCurrentStateGame()` (sufixo
+   sem função) sobrevivem porque a interface é grande demais para o que faz.
+4. **Prototype sem necessidade.** O par atual/próximo é mantido por
+   `IState::clone()` (duas clonagens já no construtor). Com posse clara dos
+   estados dentro do router, `std::move` basta e `clone()` perde o último
+   caller da engine.
+
+Pergunta de fundo (levantada na avaliação de arquitetura): **de quem é a
+responsabilidade pelo gerenciamento de telas?**
+
+## Objetivo
+
+Uma responsabilidade por peça:
+
+- **Router** = dono da **máquina de estados** (atual/próximo, request/commit,
+  política de unload na transição).
+- **SceneRepository** = **provedor de cenas** (registro de factories,
+  instanciação lazy, cache, unload) — sem nenhuma noção de estado.
+
+## Opções (decidir na tarefa)
+
+1. **Router dono dos estados; Repository só provê cenas (recomendada).**
+
+   ```cpp
+   // ISceneRepository enxuto: provisionamento, zero navegação
+   class ISceneRepository {
+   public:
+       virtual ~ISceneRepository() = default;
+       virtual void registerFactory(const std::string& name,
+                                    std::function<std::unique_ptr<core::IScene>()> factory) = 0;
+       [[nodiscard]] virtual core::IScene& getScene(const std::string& name) = 0;
+       virtual void unloadScene(const std::string& name) = 0;
+       virtual void unloadAll() = 0;
+   };
+
+   // RouterInMemory: dono da máquina de estados
+   class RouterInMemory final : public IRouter {
+       std::shared_ptr<ISceneRepository> m_scenes;
+       std::unique_ptr<IState> m_currentState;
+       std::unique_ptr<IState> m_nextState; // nullptr = nada pendente
+   public:
+       RouterInMemory(std::shared_ptr<ISceneRepository> scenes,
+                      std::unique_ptr<IState> initialState);
+
+       void requestState(std::unique_ptr<IState> state) override; // m_nextState = move(state)
+       bool hasPendingStateChange() const override;               // m_nextState != nullptr
+       void commitStateChange() override;  // unload(atual) + m_currentState = move(m_nextState)
+       // currentState()/currentScene() como hoje
+   };
+   ```
+
+   Consequências boas que vêm de graça:
+   - `hasPendingStateChange()` existe em **um** lugar (`m_nextState != nullptr`
+     em vez de comparar códigos — também corrige o caso "request para o mesmo
+     código" ser indistinguível de "nada pendente").
+   - `persisteCurrentState`/`persistNextState`/`getCurrentStateGame`/
+     `getNextStateGame` deixam de existir — os nomes ruins morrem com a
+     interface.
+   - `IState::clone()` fica **sem caller na engine** → pode ser removida da
+     interface (fecha a evolução prevista na tarefa 10, opção 3, sem esforço
+     extra).
+   - A `IRouter` (porta pública) **não muda** — o redesenho é interno ao módulo.
+
+2. **Fusão total: Router absorve factories e cache; Repository some.** Menos
+   peças, porém mistura política de navegação com política de caching — e a
+   dupla fase request/commit passa a conviver com mapa de factories na mesma
+   classe. Ganha pouco sobre a opção 1 e perde o ponto de extensão de
+   provisionamento (ex.: repositório que pré-carrega cenas).
+
+3. **Tirar o gerenciamento de cenas da engine (fica no jogo).** O módulo
+   routing passa a conter só a máquina de estados; a resolução estado→cena é
+   injetada pelo jogo (ex.: `std::function<core::IScene&(const IState&)>` no
+   router, ou o jogo implementa `ISceneRepository` por conta própria). É a
+   leitura mais radical de "talvez sair desse projeto": a engine não opina
+   sobre caching/factory de telas. Custo: todo consumidor reimplementa
+   provisionamento (e os bugs de lifetime que a tarefa 06 já pagou para
+   resolver); o valor do módulo routing cai pela metade.
+
+> Recomendação: **opção 1**. Mantém o módulo útil e o breaking mínimo (a porta
+> `IRouter` não muda; muda a fiação no `main` do jogo). A opção 3 fica
+> registrada como direção possível caso o routing vire estorvo — o desenho da
+> opção 1 não a impede: com o repository já reduzido a provedor, trocá-lo por
+> uma implementação do jogo é plugável.
+
+## Passos
+
+1. Enxugar `ISceneRepository` para os 4 métodos de provisionamento; mover
+   atual/próximo para dentro de `RouterInMemory` (com `m_nextState = nullptr`
+   como "nada pendente"; `commitStateChange()` mantém o unload da cena que sai).
+2. Novo construtor `RouterInMemory(repository, initialState)`; atualizar a
+   montagem nos testes.
+3. Remover `IState::clone()` (sem caller) e simplificar implementações nos
+   testes/mocks.
+4. Atualizar `MockSceneRepository` (encolhe) e redistribuir os testes:
+   máquina de estados → `RouterInMemoryTest`; factories/cache/unload →
+   `SceneRepositoryTest`. `SceneLifetimeTest` deve continuar passando sem
+   mudança de asserções (o contrato de lifetime não muda).
+5. Revisar o Doxygen das duas interfaces (a divisão de papéis vira a primeira
+   linha de cada uma) e o diagrama do ADR 0001 se necessário.
+
+## Critérios de aceite
+
+- [ ] `ISceneRepository` sem nenhum método de estado/navegação.
+- [ ] `RouterInMemory` é o único dono do par atual/próximo;
+      `hasPendingStateChange()` implementado por ponteiro nulo, não por
+      comparação de código.
+- [ ] `IState` sem `clone()`.
+- [ ] Porta `IRouter` inalterada; `GameManager` inalterado (fora renomes).
+- [ ] Suíte verde (incluindo `SceneLifetimeTest` sem mudanças de asserção).
+
+## Riscos
+
+Médio: mexe em interface com mocks e testes em cima, e quebra a fiação do
+consumidor. Mitigação: a porta `IRouter` congelada limita o raio da explosão;
+fazer depois da 12 (IScene menor = menos mocks para tocar duas vezes).
+
+## Pendências fora do escopo
+
+- **8Puzzle:** o `main.cpp` semeia o `SceneRepository` com o estado inicial e o
+  compartilha com o `GameRouter` do jogo. Na nova fiação, o estado inicial vai
+  para o `RouterInMemory`, e a fachada `GameRouter` deve passar a envolver o
+  `IRouter` (não o repositório). Ajustar ao consumir a 0.2.0.
+- **Política de keep-alive de cenas** (não destruir a cena que sai no commit):
+  fica mais fácil depois desta tarefa (é decisão isolada dentro de
+  `commitStateChange()`), mas é tarefa própria — depende da 12 para `onEnter`
+  voltar a rodar em cenas mantidas vivas.

--- a/.ai/task/13-router-repository-responsibilities.md
+++ b/.ai/task/13-router-repository-responsibilities.md
@@ -123,6 +123,14 @@ Uma responsabilidade por peça:
 
 ## Critérios de aceite
 
+- [ ] **Eviction da cena ativa resolvido** (achado do review do PR #11): com o
+      router dono da política de unload, descarregar a cena do estado ativo
+      sem navegação deve (a) ser impossível pela API pública, ou (b) disparar
+      reativação (`onEnter()` na instância recriada). Hoje a recriação lazy
+      após `unloadScene`/`unloadAll` devolve uma cena que nunca recebe
+      `onEnter()`, porque o tracking do `GameManager` é por código de estado
+      (rastrear por ponteiro não serve: o alocador tende a reusar o endereço
+      na recriação imediata). Cobrir com teste de integração.
 - [ ] `ISceneRepository` sem nenhum método de estado/navegação.
 - [ ] `RouterInMemory` é o único dono do par atual/próximo;
       `hasPendingStateChange()` implementado por ponteiro nulo, não por

--- a/.ai/task/README.md
+++ b/.ai/task/README.md
@@ -24,6 +24,10 @@ segurança barata** e **separando "mover" de "redesenhar"**.
    ciclo de vida das cenas — agora no lugar final.
 5. **Ecossistema/build (07–08):** padrão C++, presets, CI.
 6. **Limpeza final e documentação (09–11).**
+7. **Ciclo 0.2.0 — design de API (12 → 13):** primeiro tirar a contabilidade
+   de `onEnter` da `IScene` (12, cirurgia pequena), depois separar Router
+   (máquina de estados) de Repository (provedor de cenas) (13). As duas são
+   *breaking* — agrupar no bump 0.2.0.
 
 > Regra prática: manter a suíte de testes **verde a cada tarefa**. Nenhuma
 > tarefa deve ser mergeada com testes quebrados.
@@ -57,6 +61,8 @@ Ler antes de executar as tarefas de arquitetura:
 | 09 | [Higiene de código (includes, código morto)](09-code-hygiene.md) | 🟢 Baixa | Boas práticas |
 | 10 | [Eliminar magic string e estados *stringly-typed*](10-typed-states.md) | 🟢 Baixa | Boas práticas |
 | 11 | [Documentação (Doxygen + uso no README)](11-documentation.md) | 🟢 Baixa | Documentação |
+| 12 | [Tirar a contabilidade de ativação (`onEnter`) da `IScene`](12-scene-activation-bookkeeping.md) | 🟡 Média | Arquitetura |
+| 13 | [Separar responsabilidades: Router × Repository](13-router-repository-responsibilities.md) | 🔴 Alta (arq.) | Arquitetura |
 
 ## Legenda de status
 

--- a/core/include/cengine/core/IGameManager.hpp
+++ b/core/include/cengine/core/IGameManager.hpp
@@ -17,7 +17,9 @@ class IGameManager {
 public:
     virtual ~IGameManager() = default;
 
-    /// Ativa/entra na cena atual (idempotente por ativação — ver IScene).
+    /// Ativa/entra na cena atual. Deve ser idempotente por ativação: chamado
+    /// toda iteração, mas só efetiva a entrada uma vez por cena ativada (a
+    /// contabilidade é do implementador, não da cena — ver IScene).
     virtual void onEnter() = 0;
 
     /// Renderiza a cena atual.

--- a/core/include/cengine/core/IScene.hpp
+++ b/core/include/cengine/core/IScene.hpp
@@ -14,9 +14,9 @@ namespace cengine::core {
  * `onEnter()` (só na primeira vez em que a cena é ativada) → `input()` →
  * `draw()`. Ao trocar de cena, a cena que sai recebe `onExit()`.
  *
- * O par `onEnterExecuted()`/`isOnEnterExecuted()` existe para garantir que
- * `onEnter()` rode **uma única vez** por ativação, mesmo que a cena permaneça
- * ativa por muitas iterações.
+ * A garantia de que `onEnter()` roda **uma única vez** por ativação é do
+ * orquestrador (ex.: `cengine::routing::GameManager`), não da cena — a
+ * implementação não precisa (nem deve) manter flag de "já ativada".
  *
  * @note Contrato de tempo de vida: referências a uma cena obtidas via
  *       `cengine::routing::IRouter::currentScene()` só valem até a próxima
@@ -24,18 +24,11 @@ namespace cengine::core {
  */
 class IScene {
 public:
-    IScene() = default;
     virtual ~IScene() = default;
 
     /// Inicialização única da cena (carregar recursos, montar objetos).
     /// Chamado uma vez por ativação, antes do primeiro `input()`/`draw()`.
     virtual void onEnter() = 0;
-
-    /// Marca `onEnter()` como já executado (chamado pela engine após `onEnter()`).
-    virtual void onEnterExecuted() = 0;
-
-    /// @return true se `onEnter()` já rodou nesta ativação (evita reexecução).
-    [[nodiscard]] virtual bool isOnEnterExecuted() const = 0;
 
     /// Desenha o quadro atual. Chamado toda iteração enquanto a cena está ativa.
     virtual void draw() = 0;

--- a/modules/routing/include/cengine/routing/GameManager.hpp
+++ b/modules/routing/include/cengine/routing/GameManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <cengine/core/IGameManager.hpp>
 #include <cengine/routing/IRouter.hpp>
@@ -14,9 +15,14 @@ namespace cengine::routing {
  * cada callback do loop é delegado à cena atual obtida do roteador, e `onExit()`
  * efetiva uma eventual troca de estado pendente. `shouldExit()` compara o estado
  * atual com `kExitStateCode`.
+ *
+ * A contabilidade "a cena atual já recebeu `onEnter()`?" é interna a esta
+ * classe (código do estado ativado, resetado no commit da navegação) — a
+ * `IScene` não carrega flag de ativação. Ver .ai/task/12.
  */
 class GameManager : public core::IGameManager {
     std::shared_ptr<IRouter> m_routerService;
+    std::string m_enteredStateCode; // vazio = nenhuma cena ativada nesta rota
 public:
     explicit GameManager(std::shared_ptr<IRouter> routerService);
 

--- a/modules/routing/include/cengine/routing/ISceneRepository.hpp
+++ b/modules/routing/include/cengine/routing/ISceneRepository.hpp
@@ -41,9 +41,16 @@ public:
     virtual core::IScene& getScene(const std::string& name) = 0;
 
     /// Descarrega a cena @p name (será recriada via factory se pedida de novo).
+    /// @warning Não descarregue a cena do estado ATIVO sem uma navegação
+    ///          pendente: a recriação lazy devolve uma instância nova sem que
+    ///          `onEnter()` rode de novo (a contabilidade de ativação do
+    ///          `GameManager` assume que a cena ativa vive até o commit da
+    ///          navegação). A política de eviction será centralizada no router
+    ///          na task 13.
     virtual void unloadScene(const std::string& name) = 0;
 
     /// Descarrega todas as cenas instanciadas.
+    /// @warning Mesma restrição de `unloadScene()` quanto à cena ativa.
     virtual void unloadAll() = 0;
 
     /// @return true se o próximo estado difere do atual (troca pendente).

--- a/modules/routing/src/GameManager.cpp
+++ b/modules/routing/src/GameManager.cpp
@@ -13,9 +13,12 @@ namespace cengine::routing {
 GameManager::GameManager(std::shared_ptr<IRouter> routerService) : m_routerService(std::move(routerService)){}
 
 void GameManager::onEnter() {
-    if (core::IScene& scene = m_routerService->currentScene(); !scene.isOnEnterExecuted()) {
-        scene.onEnter();
-        scene.onEnterExecuted();
+    // A ativação é rastreada aqui (não na cena): compara o código do estado
+    // atual com o último ativado; o registro é limpo no commit da navegação.
+    const std::string code = m_routerService->currentState().getCode();
+    if (code != m_enteredStateCode) {
+        m_routerService->currentScene().onEnter();
+        m_enteredStateCode = code;
     }
 }
 
@@ -48,6 +51,10 @@ void GameManager::onExit() {
     }
 
     m_routerService->commitStateChange();
+
+    // A navegação foi efetivada: a próxima iteração deve ativar a nova cena,
+    // mesmo que o código do estado se repita (ex.: A -> B -> A).
+    m_enteredStateCode.clear();
 }
 
 bool GameManager::shouldExit() const {

--- a/tests/mock/MockScene.hpp
+++ b/tests/mock/MockScene.hpp
@@ -6,8 +6,6 @@
 class MockScene : public cengine::core::IScene {
 public:
     MOCK_METHOD(void, onEnter, (), (override));
-    MOCK_METHOD(bool, isOnEnterExecuted, (), (const, override));
-    MOCK_METHOD(void, onEnterExecuted, (), (override));
     MOCK_METHOD(void, draw, (), (override));
     MOCK_METHOD(void, input, (), (override));
     MOCK_METHOD(void, onExit, (), (override));

--- a/tests/routing/GameManagerTest.cpp
+++ b/tests/routing/GameManagerTest.cpp
@@ -28,21 +28,46 @@ protected:
     }
 };
 
-TEST_F(GameManagerTest, OnEnter_WhenSceneNotInitialized_CallsOnEnter) {
+TEST_F(GameManagerTest, OnEnter_FirstActivation_CallsOnEnterOnScene) {
+    EXPECT_CALL(*m_mockRouter, currentState()).WillOnce(testing::ReturnRef(m_mockState));
+    EXPECT_CALL(m_mockState, getCode()).WillOnce(testing::Return("main_menu"));
     EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
-    EXPECT_CALL(m_mockScene, isOnEnterExecuted()).WillOnce(testing::Return(false));
     EXPECT_CALL(m_mockScene, onEnter()).Times(1);
-    EXPECT_CALL(m_mockScene, onEnterExecuted()).Times(1);
 
     m_gameManager->onEnter();
 }
 
-TEST_F(GameManagerTest, OnEnter_WhenSceneAlreadyInitialized_DoesNothing) {
+TEST_F(GameManagerTest, OnEnter_SameStateOnNextIterations_DoesNotReenter) {
+    EXPECT_CALL(*m_mockRouter, currentState()).WillRepeatedly(testing::ReturnRef(m_mockState));
+    EXPECT_CALL(m_mockState, getCode()).WillRepeatedly(testing::Return("main_menu"));
+    // A cena só é tocada na primeira ativação; nas iterações seguintes o
+    // GameManager nem resolve a cena.
     EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
-    EXPECT_CALL(m_mockScene, isOnEnterExecuted()).WillOnce(testing::Return(true));
-    EXPECT_CALL(m_mockScene, onEnter()).Times(0);
-    EXPECT_CALL(m_mockScene, onEnterExecuted()).Times(0);
+    EXPECT_CALL(m_mockScene, onEnter()).Times(1);
 
+    m_gameManager->onEnter();
+    m_gameManager->onEnter();
+    m_gameManager->onEnter();
+}
+
+TEST_F(GameManagerTest, OnEnter_AfterCommittedNavigation_ReentersEvenWithSameStateCode) {
+    EXPECT_CALL(*m_mockRouter, currentState()).WillRepeatedly(testing::ReturnRef(m_mockState));
+    EXPECT_CALL(m_mockState, getCode()).WillRepeatedly(testing::Return("gameplay"));
+    EXPECT_CALL(*m_mockRouter, currentScene()).WillRepeatedly(testing::ReturnRef(m_mockScene));
+
+    // 1ª ativação.
+    EXPECT_CALL(m_mockScene, onEnter()).Times(1);
+    m_gameManager->onEnter();
+
+    // Navegação efetivada (commit) deve limpar o registro de ativação...
+    EXPECT_CALL(*m_mockRouter, hasPendingStateChange()).WillOnce(testing::Return(true));
+    EXPECT_CALL(m_mockScene, onExit()).Times(1);
+    EXPECT_CALL(*m_mockRouter, commitStateChange()).Times(1);
+    m_gameManager->onExit();
+
+    // ...então a próxima iteração reativa a cena, mesmo com o mesmo código
+    // (proteção para futuras políticas de keep-alive — A -> B -> A).
+    EXPECT_CALL(m_mockScene, onEnter()).Times(1);
     m_gameManager->onEnter();
 }
 

--- a/tests/routing/integration/SceneLifetimeTest.cpp
+++ b/tests/routing/integration/SceneLifetimeTest.cpp
@@ -37,23 +37,22 @@ public:
     }
 };
 
-// Cena que rastreia seu tempo de vida (contador de instâncias vivas) e se seu
-// onExit() foi chamado. Permite provar que a navegação destrói a cena antiga.
+// Cena que rastreia seu tempo de vida (contador de instâncias vivas), quantas
+// vezes foi ativada (onEnter) e se seu onExit() foi chamado. Permite provar que
+// a navegação destrói a cena antiga e que a reativação acontece via engine.
 class TrackedScene final : public IScene {
     int* m_liveCount;
     bool* m_onExitCalled;
-    bool m_onEnterExecuted{false};
+    int* m_onEnterCount;
 
 public:
-    TrackedScene(int* liveCount, bool* onExitCalled)
-        : m_liveCount(liveCount), m_onExitCalled(onExitCalled) {
+    TrackedScene(int* liveCount, bool* onExitCalled, int* onEnterCount)
+        : m_liveCount(liveCount), m_onExitCalled(onExitCalled), m_onEnterCount(onEnterCount) {
         ++(*m_liveCount);
     }
     ~TrackedScene() override { --(*m_liveCount); }
 
-    void onEnter() override {}
-    void onEnterExecuted() override { m_onEnterExecuted = true; }
-    [[nodiscard]] bool isOnEnterExecuted() const override { return m_onEnterExecuted; }
+    void onEnter() override { ++(*m_onEnterCount); }
     void draw() override {}
     void input() override {}
     void onExit() override { *m_onExitCalled = true; }
@@ -67,6 +66,8 @@ protected:
     int liveB{0};
     bool onExitCalledA{false};
     bool onExitCalledB{false};
+    int onEnterCountA{0};
+    int onEnterCountB{0};
 
     std::shared_ptr<SceneRepository> repository;
     std::shared_ptr<RouterInMemory> router;
@@ -75,10 +76,10 @@ protected:
     void SetUp() override {
         repository = std::make_shared<SceneRepository>(std::make_unique<FakeState>("A"));
         repository->registerFactory("A", [this]() {
-            return std::make_unique<TrackedScene>(&liveA, &onExitCalledA);
+            return std::make_unique<TrackedScene>(&liveA, &onExitCalledA, &onEnterCountA);
         });
         repository->registerFactory("B", [this]() {
-            return std::make_unique<TrackedScene>(&liveB, &onExitCalledB);
+            return std::make_unique<TrackedScene>(&liveB, &onExitCalledB, &onEnterCountB);
         });
 
         router = std::make_shared<RouterInMemory>(repository);
@@ -111,4 +112,29 @@ TEST_F(SceneLifetimeTest, NavigateUnloadsPreviousSceneWithoutDanglingAccess) {
     // memória da cena A já liberada.
     gameManager->onEnter();
     EXPECT_EQ(liveB, 1);
+}
+
+// Regressão para .ai/task/12: navegar A -> B -> A deve REATIVAR a cena A
+// (onEnter roda de novo na volta). Hoje isso é sustentado pelo unload no
+// commit + reset do tracking no GameManager; o teste protege o comportamento
+// caso a política de unload mude (ex.: keep-alive de cenas).
+TEST_F(SceneLifetimeTest, NavigatingBackReactivatesScene) {
+    // Ativa A.
+    gameManager->onEnter();
+    EXPECT_EQ(onEnterCountA, 1);
+
+    // A -> B.
+    router->requestState(std::make_unique<FakeState>("B"));
+    gameManager->onExit();
+    gameManager->onEnter();
+    EXPECT_EQ(onEnterCountB, 1);
+
+    // B -> A: a volta deve reativar A (nova ativação, novo onEnter).
+    router->requestState(std::make_unique<FakeState>("A"));
+    gameManager->onExit();
+    gameManager->onEnter();
+
+    EXPECT_EQ(onEnterCountA, 2);
+    EXPECT_EQ(liveA, 1);
+    EXPECT_EQ(liveB, 0); // B foi descarregada na volta
 }


### PR DESCRIPTION
## Resumo

Executa a **task 12** (`.ai/task/12-scene-activation-bookkeeping.md`): remove o par `onEnterExecuted()`/`isOnEnterExecuted()` da porta `IScene`. A garantia de que `onEnter()` roda **uma unica vez por ativacao** passa a ser responsabilidade do orquestrador (`GameManager`), invisivel para o jogo.

**BREAKING CHANGE** — primeiro item do ciclo 0.2.0 (junto da task 13, que vem em PR separado).

## Motivacao

- O par de metodos era contabilidade da engine vazando para o implementador: toda cena de todo jogo precisava carregar um boolean e implementar os dois metodos corretamente (2 dos 6 metodos da interface serviam a orquestracao, nao a cena).
- Acoplamento escondido: o flag so resetava porque `commitStateChange()` destroi a cena que sai. Com uma futura politica de keep-alive, `onEnter()` nunca mais rodaria ao voltar para uma cena mantida viva.

## Mudancas

- `IScene` reduzida a 4 metodos coesos: `onEnter`, `input`, `draw`, `onExit`.
- `GameManager` ganha `m_enteredStateCode`: ativa a cena so quando o codigo do estado atual difere do ultimo ativado; o registro e limpo apos `commitStateChange()` em `onExit()` — o que garante reativacao no cenario A→B→A independente da politica de unload.
- De carona: nas iteracoes em que a cena ja esta ativada, `onEnter()` nem resolve a cena no router (compara so o codigo do estado).
- Doxygen de `IScene` e `IGameManager` atualizado com o novo contrato.

## Testes (30/30 ✅)

- `OnEnter_SameStateOnNextIterations_DoesNotReenter` — 1x por ativacao.
- `OnEnter_AfterCommittedNavigation_ReentersEvenWithSameStateCode` — commit reseta o tracking.
- `SceneLifetimeTest.NavigatingBackReactivatesScene` — regressao de integracao A→B→A com as implementacoes reais, contando ativacoes por cena (protege o comportamento se a politica de unload mudar).
- Os 2 testes antigos de `onEnter` foram reescritos para a nova semantica (expectativa sobre chamadas a `scene.onEnter()`, nao sobre flag).

## Impacto no consumidor (8Puzzle)

Ao consumir a 0.2.0, remover o flag/metodos de ativacao das cenas (`TerminalScene` e derivadas) — e simplificacao, nao reescrita. Registrado como pendencia na task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)