### PR TITLE
refactor(routing)!: router dono da maquina de estados e do repositorio (task 13)

### DIFF
--- a/.ai/task/13-router-repository-responsibilities.md
+++ b/.ai/task/13-router-repository-responsibilities.md
@@ -1,6 +1,6 @@
 # 13 — Separar responsabilidades: Router (navegação) × Repository (cenas)
 
-- **Status:** todo
+- **Status:** done ✅ (opção 1 + posse exclusiva, 2026-07-08, branch `feature/13-router-repository-responsibilities`)
 - **Prioridade:** 🔴 Alta (arquitetural)
 - **Categoria:** Arquitetura
 - **Depende de:** 05b (API do Router estável), 12 (IScene enxuta — fazer antes,
@@ -123,7 +123,7 @@ Uma responsabilidade por peça:
 
 ## Critérios de aceite
 
-- [ ] **Eviction da cena ativa resolvido** (achado do review do PR #11): com o
+- [x] **Eviction da cena ativa resolvido** (achado do review do PR #11): com o
       router dono da política de unload, descarregar a cena do estado ativo
       sem navegação deve (a) ser impossível pela API pública, ou (b) disparar
       reativação (`onEnter()` na instância recriada). Hoje a recriação lazy
@@ -131,13 +131,43 @@ Uma responsabilidade por peça:
       `onEnter()`, porque o tracking do `GameManager` é por código de estado
       (rastrear por ponteiro não serve: o alocador tende a reusar o endereço
       na recriação imediata). Cobrir com teste de integração.
-- [ ] `ISceneRepository` sem nenhum método de estado/navegação.
-- [ ] `RouterInMemory` é o único dono do par atual/próximo;
+      → **Resolvido pela via (a), por construção**: o router assume posse
+      exclusiva do repositório (`unique_ptr` no construtor) — não sobra
+      referência externa para evictar por fora. O reload deliberado da cena
+      atual é `requestState()` com o mesmo código (nova semântica), coberto
+      pelo teste de integração
+      `SceneLifetimeTest.RequestingCurrentStateReloadsAndReactivatesScene`.
+- [x] `ISceneRepository` sem nenhum método de estado/navegação.
+- [x] `RouterInMemory` é o único dono do par atual/próximo;
       `hasPendingStateChange()` implementado por ponteiro nulo, não por
       comparação de código.
-- [ ] `IState` sem `clone()`.
-- [ ] Porta `IRouter` inalterada; `GameManager` inalterado (fora renomes).
-- [ ] Suíte verde (incluindo `SceneLifetimeTest` sem mudanças de asserção).
+- [x] `IState` sem `clone()`.
+- [x] Porta `IRouter` inalterada; `GameManager` inalterado (fora renomes).
+- [x] Suíte verde (incluindo `SceneLifetimeTest` sem mudanças de asserção).
+
+## Resultado da execução
+
+Executada a **opção 1**, com um refinamento além do desenho original: em vez de
+`shared_ptr`, o `RouterInMemory` recebe o repositório por **`unique_ptr`**
+(posse exclusiva). Isso resolve o critério do eviction pela via (a) sem crescer
+nenhuma interface.
+
+- `ISceneRepository` enxuto: `registerFactory` / `getScene` / `unloadScene` /
+  `unloadAll` — zero navegação. `SceneRepository` ficou default-construtível
+  (de carona: lookup duplo do mapa em `getScene()` eliminado via `emplace`).
+- `RouterInMemory(unique_ptr<ISceneRepository>, unique_ptr<IState> initial)`:
+  dono de `m_currentState`/`m_nextState`; pending = `m_nextState != nullptr`;
+  `commitStateChange()` com guarda de no-op. Os nomes
+  `persisteCurrentState`/`getCurrentStateGame`/etc. morreram com a interface.
+- **Mudança de semântica**: `requestState()` com o código do estado atual
+  agora é uma troca válida (reload deliberado — descarrega, recria e reativa);
+  antes era indistinguível de "nada pendente". Documentado em `IRouter`.
+- `IState` sem `clone()` (fecha a opção 3 da task 10 de carona); estados
+  movidos por `unique_ptr`, sem Prototype.
+- Testes: `RouterInMemoryTest` reescrito (máquina de estados real, 7 testes);
+  `SceneRepositoryTest` só provisionamento (6); `FakeState` compartilhado em
+  `tests/mock/`; `MockState`/`MockSceneRepository` enxugados. Suíte: **29/29**.
+- README (Minimal assembly) atualizado para a nova fiação.
 
 ## Riscos
 
@@ -147,10 +177,10 @@ fazer depois da 12 (IScene menor = menos mocks para tocar duas vezes).
 
 ## Pendências fora do escopo
 
-- **8Puzzle:** o `main.cpp` semeia o `SceneRepository` com o estado inicial e o
-  compartilha com o `GameRouter` do jogo. Na nova fiação, o estado inicial vai
-  para o `RouterInMemory`, e a fachada `GameRouter` deve passar a envolver o
-  `IRouter` (não o repositório). Ajustar ao consumir a 0.2.0.
+- **8Puzzle** (ao consumir a 0.2.0): a fachada `GameRouter` passa a envolver o
+  `IRouter` (não o repositório); o `main.cpp` registra as factories no
+  repositório e MOVE a posse para o `RouterInMemory` junto do estado inicial;
+  remover os `clone()` dos `StateGame`.
 - **Política de keep-alive de cenas** (não destruir a cena que sai no commit):
   fica mais fácil depois desta tarefa (é decisão isolada dentro de
   `commitStateChange()`), mas é tarefa própria — depende da 12 para `onEnter`

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ target_link_libraries(my_game PRIVATE
 ### Minimal assembly
 
 The engine is **graphics-agnostic**: you implement the ports (window + scenes)
-and the engine drives the loop. A minimal game wires up a window manager, a
-router over a scene repository, and hands both to the `EngineManager`:
+and the engine drives the loop. A minimal game registers its scene factories in
+a repository, hands its ownership to the router (which owns the state machine),
+and gives everything to the `EngineManager`:
 
 ```cpp
 #include <memory>
@@ -111,20 +112,19 @@ router over a scene repository, and hands both to the `EngineManager`:
 using namespace cengine;
 
 int main() {
-    // 1. Repository seeded with the initial state (you provide MyState : IState).
-    auto repository = std::make_shared<routing::SceneRepository>(
-        std::make_unique<MyState>("main_menu"));
-
-    // 2. Register a scene factory per state code (lazy instantiation).
-    //    You provide MenuScene / GameplayScene : cengine::core::IScene.
+    // 1. Repository = scene provider: register a factory per state code
+    //    (lazy instantiation). You provide MenuScene / GameplayScene : IScene.
+    auto repository = std::make_unique<routing::SceneRepository>();
     repository->registerFactory("main_menu", [] { return std::make_unique<MenuScene>(); });
     repository->registerFactory("gameplay",  [] { return std::make_unique<GameplayScene>(); });
 
-    // 3. Router over the repository, exposed to the game as an IGameManager.
-    auto router      = std::make_shared<routing::RouterInMemory>(repository);
+    // 2. Router = state machine. It takes OWNERSHIP of the repository and the
+    //    initial state (you provide MyState : IState).
+    auto router = std::make_shared<routing::RouterInMemory>(
+        std::move(repository), std::make_unique<MyState>("main_menu"));
     auto gameManager = std::make_unique<routing::GameManager>(router);
 
-    // 4. Run the loop (you provide MyWindowManager : cengine::core::IWindowManager).
+    // 3. Run the loop (you provide MyWindowManager : cengine::core::IWindowManager).
     core::EngineManager engine{
         std::make_unique<MyWindowManager>(),
         std::move(gameManager)
@@ -135,8 +135,10 @@ int main() {
 ```
 
 To navigate, a scene calls `router->requestState(std::make_unique<MyState>("gameplay"))`;
-the switch is committed at the end of the frame (`onExit`). Routing to the
-`cengine::routing::kExitStateCode` state stops the loop.
+the switch is committed at the end of the frame (`onExit`). Requesting the
+*current* state's code is a deliberate reload (the scene is destroyed, recreated
+and re-entered). Routing to the `cengine::routing::kExitStateCode` state stops
+the loop.
 
 The public headers carry Doxygen comments describing each contract — start from
 [`IScene`](core/include/cengine/core/IScene.hpp) and

--- a/modules/routing/include/cengine/routing/IRouter.hpp
+++ b/modules/routing/include/cengine/routing/IRouter.hpp
@@ -25,6 +25,8 @@ public:
     virtual ~IRouter() = default;
 
     /// Agenda a transição para @p state (efetivada depois, em commitStateChange).
+    /// Solicitar o código do estado ATUAL é válido e efetiva um reload: a cena
+    /// é descarregada, recriada e reativada (`onEnter` roda de novo).
     virtual void requestState(std::unique_ptr<IState> state) = 0;
 
     /// @return true se há uma troca de estado agendada e ainda não efetivada.

--- a/modules/routing/include/cengine/routing/ISceneRepository.hpp
+++ b/modules/routing/include/cengine/routing/ISceneRepository.hpp
@@ -4,17 +4,18 @@
 #include <functional>
 
 #include <cengine/core/IScene.hpp>
-#include <cengine/routing/IState.hpp>
 
 namespace cengine::routing {
 
 /**
- * @brief Guarda as cenas (instanciadas *lazy* via factory) e o par de estados
- *        atual/próximo que sustenta a navegação em duas fases do `IRouter`.
+ * @brief Provedor de cenas: registro de factories por código de estado,
+ *        instanciação *lazy*, cache e descarregamento.
  *
- * Cenas são criadas sob demanda a partir de factories registradas por código de
- * estado e podem ser descarregadas para liberar memória. É a peça que o
- * `RouterInMemory` usa por baixo.
+ * Não tem nenhuma noção de estado/navegação — a máquina de estados
+ * (atual/próximo, request/commit) é do `IRouter`. Na fiação recomendada o
+ * repositório pertence ao router (posse via `unique_ptr`): o jogo registra as
+ * factories e transfere a posse, de modo que nenhum componente externo pode
+ * descarregar cenas por fora do ciclo de navegação.
  */
 class ISceneRepository {
 public:
@@ -23,17 +24,6 @@ public:
     /// Registra a factory que cria a cena do estado @p name (instanciação lazy).
     virtual void registerFactory(const std::string& name, std::function<std::unique_ptr<core::IScene>()> factory) = 0;
 
-    /// @return o estado atualmente ativo.
-    virtual IState& getCurrentStateGame() const = 0;
-
-    /// @return o próximo estado agendado (igual ao atual se nada pendente).
-    virtual IState& getNextStateGame() const = 0;
-
-    /// Promove o próximo estado a atual (efetiva a troca).
-    virtual void persisteCurrentState() = 0;
-
-    /// Define o próximo estado agendado.
-    virtual void persistNextState(std::unique_ptr<IState> state) = 0;
     // Contrato de tempo de vida: a referência retornada aponta para dentro do
     // mapa interno de cenas e é invalidada por unloadScene(name)/unloadAll().
     // NÃO retenha a referência através de um desses unloads. Ver
@@ -41,20 +31,16 @@ public:
     virtual core::IScene& getScene(const std::string& name) = 0;
 
     /// Descarrega a cena @p name (será recriada via factory se pedida de novo).
-    /// @warning Não descarregue a cena do estado ATIVO sem uma navegação
-    ///          pendente: a recriação lazy devolve uma instância nova sem que
-    ///          `onEnter()` rode de novo (a contabilidade de ativação do
-    ///          `GameManager` assume que a cena ativa vive até o commit da
-    ///          navegação). A política de eviction será centralizada no router
-    ///          na task 13.
+    /// @warning Descarregar a cena do estado ATIVO fora do commit de navegação
+    ///          faz a recriação lazy devolver uma instância que não recebe
+    ///          `onEnter()`. Na fiação recomendada (router dono do repositório)
+    ///          esse caminho não existe; o reload deliberado da cena atual é
+    ///          `IRouter::requestState()` com o mesmo código de estado.
     virtual void unloadScene(const std::string& name) = 0;
 
     /// Descarrega todas as cenas instanciadas.
     /// @warning Mesma restrição de `unloadScene()` quanto à cena ativa.
     virtual void unloadAll() = 0;
-
-    /// @return true se o próximo estado difere do atual (troca pendente).
-    virtual bool hasPendingStateChange() const = 0;
 };
 
 } // namespace cengine::routing

--- a/modules/routing/include/cengine/routing/IState.hpp
+++ b/modules/routing/include/cengine/routing/IState.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <string>
 
 namespace cengine::routing {
@@ -13,9 +12,8 @@ namespace cengine::routing {
  * do estado (ex.: `"main_menu"`, `"gameplay"`, `cengine::routing::kExitStateCode`).
  * O jogo define seus próprios estados implementando esta interface.
  *
- * `clone()` segue o padrão **Prototype**: o repositório guarda cópias
- * independentes do estado atual e do próximo, sem acoplar-se ao tipo concreto —
- * por isso o estado deve saber se duplicar.
+ * Estados são possuídos pelo router (`unique_ptr` movidos via `requestState`),
+ * então a interface não exige clonagem.
  */
 class IState {
 public:
@@ -26,9 +24,6 @@ public:
 
     /// Nome legível do estado (para logs/depuração).
     [[nodiscard]] virtual std::string getName() const = 0;
-
-    /// Cria uma cópia independente deste estado (padrão Prototype).
-    [[nodiscard]] virtual std::unique_ptr<IState> clone() const = 0;
 };
 
 } // namespace cengine::routing

--- a/modules/routing/include/cengine/routing/RouterInMemory.hpp
+++ b/modules/routing/include/cengine/routing/RouterInMemory.hpp
@@ -9,17 +9,29 @@
 namespace cengine::routing {
 
 /**
- * @brief `IRouter` em memória, apoiado em um `ISceneRepository`.
+ * @brief `IRouter` em memória: dono da máquina de estados (atual/próximo),
+ *        apoiado em um `ISceneRepository` que apenas provê cenas.
  *
- * Delega o estado e as cenas ao repositório; `commitStateChange()` descarrega a
- * cena do estado que sai e promove o próximo. `currentScene()` resolve a cena do
- * estado atual sob demanda (instanciação lazy pelo repositório).
+ * O router assume a posse exclusiva do repositório: o jogo registra as
+ * factories e transfere o `unique_ptr`, de modo que nenhum componente externo
+ * pode descarregar cenas por fora do ciclo de navegação (garante por
+ * construção o contrato de ativação do `GameManager` — ver .ai/task/13).
+ *
+ * `requestState()` agenda a troca; `commitStateChange()` descarrega a cena do
+ * estado que sai e promove o próximo. Solicitar o código do estado ATUAL
+ * também é uma troca válida: o commit descarrega e recria a cena (reload
+ * deliberado).
  */
 class RouterInMemory final : public IRouter {
-    std::shared_ptr<ISceneRepository> m_sceneRepository;
+    std::unique_ptr<ISceneRepository> m_sceneRepository;
+    std::unique_ptr<IState> m_currentState;
+    std::unique_ptr<IState> m_nextState; // nullptr = nenhuma troca pendente
 
 public:
-    explicit RouterInMemory(std::shared_ptr<ISceneRepository> sceneRepository);
+    /// @param sceneRepository provedor de cenas (posse transferida ao router).
+    /// @param initialState    estado ativo no início do loop.
+    RouterInMemory(std::unique_ptr<ISceneRepository> sceneRepository,
+                   std::unique_ptr<IState> initialState);
     ~RouterInMemory() override = default;
 
     void requestState(std::unique_ptr<IState> state) override;

--- a/modules/routing/include/cengine/routing/SceneRepository.hpp
+++ b/modules/routing/include/cengine/routing/SceneRepository.hpp
@@ -6,47 +6,33 @@
 #include <unordered_map>
 
 #include <cengine/core/IScene.hpp>
-#include <cengine/routing/IState.hpp>
 #include <cengine/routing/ISceneRepository.hpp>
 
 namespace cengine::routing {
 
 /**
  * @brief `ISceneRepository` em memória: mapa de factories + cache de cenas
- *        instanciadas, com o par de estados atual/próximo.
+ *        instanciadas.
  *
  * `getScene()` instancia a cena via factory na primeira vez e a mantém em cache
- * até um `unloadScene`/`unloadAll`. Os estados são guardados como cópias
- * independentes (via `IState::clone()`), sustentando a navegação em duas fases.
+ * até um `unloadScene`/`unloadAll`. Puro provisionamento — nenhuma noção de
+ * estado/navegação (essa é do `RouterInMemory`, dono deste repositório).
  */
 class SceneRepository final : public ISceneRepository {
     std::unordered_map<std::string, std::unique_ptr<core::IScene>> m_scenes;
     std::unordered_map<std::string, std::function<std::unique_ptr<core::IScene>()>> m_factories;
 
-    std::unique_ptr<IState> m_nextState;
-    std::unique_ptr<IState> m_currentState;
-
 public:
-    explicit SceneRepository(std::unique_ptr<IState> initialState);
+    SceneRepository() = default;
     ~SceneRepository() override = default;
 
     void registerFactory(const std::string& name, std::function<std::unique_ptr<core::IScene>()> factory) override;
-
-    [[nodiscard]] IState& getCurrentStateGame() const override;
-
-    [[nodiscard]] IState& getNextStateGame() const override;
-
-    void persisteCurrentState() override;
-
-    void persistNextState(std::unique_ptr<IState> state) override;
 
     core::IScene& getScene(const std::string& name) override;
 
     void unloadScene(const std::string& name) override;
 
     void unloadAll() override;
-
-    bool hasPendingStateChange() const override;
 };
 
 } // namespace cengine::routing

--- a/modules/routing/src/RouterInMemory.cpp
+++ b/modules/routing/src/RouterInMemory.cpp
@@ -1,32 +1,37 @@
 #include <cengine/routing/RouterInMemory.hpp>
 
-#include <string>
 #include <utility>
 
 namespace cengine::routing {
 
-RouterInMemory::RouterInMemory(std::shared_ptr<ISceneRepository> sceneRepository) : m_sceneRepository(std::move(sceneRepository)) {}
+RouterInMemory::RouterInMemory(std::unique_ptr<ISceneRepository> sceneRepository,
+                               std::unique_ptr<IState> initialState)
+    : m_sceneRepository(std::move(sceneRepository)),
+      m_currentState(std::move(initialState)) {}
 
 void RouterInMemory::requestState(std::unique_ptr<IState> state) {
-    m_sceneRepository->persistNextState(std::move(state));
+    m_nextState = std::move(state);
 }
 
 bool RouterInMemory::hasPendingStateChange() const {
-    return m_sceneRepository->hasPendingStateChange();
+    return m_nextState != nullptr;
 }
 
 void RouterInMemory::commitStateChange() {
-    const std::string currentStateCode = m_sceneRepository->getCurrentStateGame().getCode();
-    m_sceneRepository->unloadScene(currentStateCode);
-    m_sceneRepository->persisteCurrentState();
+    if (!m_nextState) {
+        return;
+    }
+
+    m_sceneRepository->unloadScene(m_currentState->getCode());
+    m_currentState = std::move(m_nextState);
 }
 
 const IState& RouterInMemory::currentState() const {
-    return m_sceneRepository->getCurrentStateGame();
+    return *m_currentState;
 }
 
 core::IScene& RouterInMemory::currentScene() {
-    return m_sceneRepository->getScene(currentState().getCode());
+    return m_sceneRepository->getScene(m_currentState->getCode());
 }
 
 } // namespace cengine::routing

--- a/modules/routing/src/SceneRepository.cpp
+++ b/modules/routing/src/SceneRepository.cpp
@@ -2,44 +2,21 @@
 
 namespace cengine::routing {
 
-SceneRepository::SceneRepository(std::unique_ptr<IState> initialState){
-    m_nextState = initialState->clone();
-    m_currentState = initialState->clone();
-}
-
 void SceneRepository::registerFactory(const std::string &name, std::function<std::unique_ptr<core::IScene>()> factory)
 {
     m_factories[name] = std::move(factory);
 }
 
-IState &SceneRepository::getCurrentStateGame() const {
-    return *m_currentState;
-}
-
-IState &SceneRepository::getNextStateGame() const {
-    return *m_nextState;
-}
-
-void SceneRepository::persisteCurrentState() {
-    m_currentState = m_nextState->clone();
-}
-
-void SceneRepository::persistNextState(std::unique_ptr<IState> state) {
-    m_nextState = std::move(state);
-}
-
 core::IScene &SceneRepository::getScene(const std::string &name) {
     // Se já estiver instanciada, retorna
-    const auto it = m_scenes.find(name);
-    if (it != m_scenes.end()) {
+    if (const auto it = m_scenes.find(name); it != m_scenes.end()) {
         return *(it->second);
     }
 
     // Caso contrário, instancia sob demanda via factory
-    const auto factoryIt = m_factories.find(name);
-    if (factoryIt != m_factories.end()) {
-        m_scenes[name] = factoryIt->second();
-        return *(m_scenes[name]);
+    if (const auto factoryIt = m_factories.find(name); factoryIt != m_factories.end()) {
+        const auto [it, inserted] = m_scenes.emplace(name, factoryIt->second());
+        return *(it->second);
     }
 
     throw std::runtime_error("Scene not found: " + name);
@@ -51,10 +28,6 @@ void SceneRepository::unloadScene(const std::string &name) {
 
 void SceneRepository::unloadAll() {
     m_scenes.clear();
-}
-
-bool SceneRepository::hasPendingStateChange() const {
-    return m_nextState->getCode() != m_currentState->getCode();
 }
 
 } // namespace cengine::routing

--- a/tests/mock/FakeState.hpp
+++ b/tests/mock/FakeState.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include <cengine/routing/IState.hpp>
+
+// IState mínimo para testes: carrega apenas o código (nome = código).
+class FakeState final : public cengine::routing::IState {
+    std::string m_code;
+
+public:
+    explicit FakeState(std::string code) : m_code(std::move(code)) {}
+
+    [[nodiscard]] std::string getCode() const override { return m_code; }
+    [[nodiscard]] std::string getName() const override { return m_code; }
+};

--- a/tests/mock/MockSceneRepository.hpp
+++ b/tests/mock/MockSceneRepository.hpp
@@ -8,12 +8,7 @@
 class MockSceneRepository : public cengine::routing::ISceneRepository {
 public:
     MOCK_METHOD(void, registerFactory, (const std::string&, std::function<std::unique_ptr<cengine::core::IScene>()>), (override));
-    MOCK_METHOD(cengine::routing::IState&, getCurrentStateGame, (), (const, override));
-    MOCK_METHOD(cengine::routing::IState&, getNextStateGame, (), (const, override));
-    MOCK_METHOD(void, persisteCurrentState, (), (override));
-    MOCK_METHOD(void, persistNextState, (std::unique_ptr<cengine::routing::IState> state), (override));
     MOCK_METHOD(cengine::core::IScene&, getScene, (const std::string& name), (override));
     MOCK_METHOD(void, unloadScene, (const std::string& name), (override));
     MOCK_METHOD(void, unloadAll, (), (override));
-    MOCK_METHOD(bool, hasPendingStateChange, (), (const, override));
 };

--- a/tests/mock/MockState.hpp
+++ b/tests/mock/MockState.hpp
@@ -7,9 +7,4 @@ class MockState : public cengine::routing::IState {
 public:
     MOCK_METHOD(std::string, getCode, (), (const, override));
     MOCK_METHOD(std::string, getName, (), (const, override));
-    MOCK_METHOD(std::unique_ptr<cengine::routing::IState>, clone, (), (const, override));
-
-    std::unique_ptr<cengine::routing::IState> cloneMock() const {
-        return std::make_unique<MockState>();
-    }
 };

--- a/tests/routing/RouterInMemoryTest.cpp
+++ b/tests/routing/RouterInMemoryTest.cpp
@@ -8,71 +8,76 @@
 #include <cengine/routing/IState.hpp>
 #include <cengine/routing/RouterInMemory.hpp>
 
+#include <mock/FakeState.hpp>
 #include <mock/MockScene.hpp>
 #include <mock/MockSceneRepository.hpp>
-#include <mock/MockState.hpp>
 
 using namespace cengine::core;
 using namespace cengine::routing;
 
+// O router é o dono da máquina de estados (task 13): os testes exercitam o
+// par atual/próximo de verdade e usam o repositório mockado apenas para
+// observar o provisionamento (getScene/unloadScene).
 class RouterInMemoryTest : public ::testing::Test {
 protected:
-    std::shared_ptr<MockSceneRepository> mockSceneRepository;
+    MockSceneRepository* mockSceneRepository{nullptr}; // observado; posse é do router
     std::unique_ptr<RouterInMemory> routerService;
 
-    MockState mockCurrentState;
     MockScene mockScene;
 
     void SetUp() override {
-        mockSceneRepository = std::make_shared<MockSceneRepository>();
-        routerService = std::make_unique<RouterInMemory>(mockSceneRepository);
+        auto repository = std::make_unique<MockSceneRepository>();
+        mockSceneRepository = repository.get();
+        routerService = std::make_unique<RouterInMemory>(
+            std::move(repository), std::make_unique<FakeState>("A"));
     }
 };
 
-TEST_F(RouterInMemoryTest, RequestStateDelegatesToRepository) {
-    auto newState = std::make_unique<MockState>();
-
-    EXPECT_CALL(*mockSceneRepository, persistNextState(testing::A<std::unique_ptr<IState>>())).Times(1);
-
-    routerService->requestState(std::move(newState));
+TEST_F(RouterInMemoryTest, CurrentStateIsTheInitialState) {
+    ASSERT_EQ(routerService->currentState().getCode(), "A");
 }
 
-TEST_F(RouterInMemoryTest, CurrentStateDelegatesCorrectly) {
-    EXPECT_CALL(*mockSceneRepository, getCurrentStateGame()).WillOnce(testing::ReturnRef(mockCurrentState));
-
-    const IState& returnedState = routerService->currentState();
-
-    ASSERT_EQ(&returnedState, &mockCurrentState);
+TEST_F(RouterInMemoryTest, HasPendingStateChangeIsFalseInitially) {
+    ASSERT_FALSE(routerService->hasPendingStateChange());
 }
 
-TEST_F(RouterInMemoryTest, CurrentSceneDelegatesCorrectly) {
-    const std::string expectedCode = "MENU";
+TEST_F(RouterInMemoryTest, RequestStateSchedulesWithoutChangingCurrentState) {
+    routerService->requestState(std::make_unique<FakeState>("B"));
 
-    EXPECT_CALL(*mockSceneRepository, getCurrentStateGame()).WillOnce(testing::ReturnRef(mockCurrentState));
-    EXPECT_CALL(mockCurrentState, getCode()).WillOnce(testing::Return(expectedCode));
-    EXPECT_CALL(*mockSceneRepository, getScene(expectedCode)).WillOnce(testing::ReturnRef(mockScene));
+    ASSERT_TRUE(routerService->hasPendingStateChange());
+    ASSERT_EQ(routerService->currentState().getCode(), "A"); // troca ainda não efetivada
+}
+
+TEST_F(RouterInMemoryTest, RequestStateWithSameCodeSchedulesReload) {
+    // Pedir o código do estado atual é uma troca válida (reload deliberado da
+    // cena) — antes da task 13 isso era indistinguível de "nada pendente".
+    routerService->requestState(std::make_unique<FakeState>("A"));
+
+    ASSERT_TRUE(routerService->hasPendingStateChange());
+}
+
+TEST_F(RouterInMemoryTest, CommitStateChangeUnloadsOldSceneAndPromotesNext) {
+    EXPECT_CALL(*mockSceneRepository, unloadScene("A")).Times(1);
+
+    routerService->requestState(std::make_unique<FakeState>("B"));
+    routerService->commitStateChange();
+
+    ASSERT_EQ(routerService->currentState().getCode(), "B");
+    ASSERT_FALSE(routerService->hasPendingStateChange());
+}
+
+TEST_F(RouterInMemoryTest, CommitStateChangeWithoutPendingChangeIsNoOp) {
+    EXPECT_CALL(*mockSceneRepository, unloadScene(testing::_)).Times(0);
+
+    routerService->commitStateChange();
+
+    ASSERT_EQ(routerService->currentState().getCode(), "A");
+}
+
+TEST_F(RouterInMemoryTest, CurrentSceneResolvesSceneOfCurrentState) {
+    EXPECT_CALL(*mockSceneRepository, getScene("A")).WillOnce(testing::ReturnRef(mockScene));
 
     IScene& returnedScene = routerService->currentScene();
 
     ASSERT_EQ(&returnedScene, &mockScene);
-}
-
-TEST_F(RouterInMemoryTest, CommitStateChangeCallsMethodsInCorrectOrder) {
-    const std::string expectedCode = "OLD_SCENE";
-    testing::InSequence sequence;
-
-    EXPECT_CALL(*mockSceneRepository, getCurrentStateGame()).WillOnce(testing::ReturnRef(mockCurrentState));
-    EXPECT_CALL(mockCurrentState, getCode()).WillOnce(testing::Return(expectedCode));
-    EXPECT_CALL(*mockSceneRepository, unloadScene(expectedCode)).Times(1);
-    EXPECT_CALL(*mockSceneRepository, persisteCurrentState()).Times(1);
-
-    routerService->commitStateChange();
-}
-
-TEST_F(RouterInMemoryTest, HasPendingStateChangeDelegatesCorrectly) {
-    EXPECT_CALL(*mockSceneRepository, hasPendingStateChange()).WillOnce(testing::Return(true));
-    ASSERT_TRUE(routerService->hasPendingStateChange());
-
-    EXPECT_CALL(*mockSceneRepository, hasPendingStateChange()).WillOnce(testing::Return(false));
-    ASSERT_FALSE(routerService->hasPendingStateChange());
 }

--- a/tests/routing/SceneRepositoryTest.cpp
+++ b/tests/routing/SceneRepositoryTest.cpp
@@ -1,10 +1,8 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-#include <cengine/routing/IState.hpp>
 #include <cengine/core/IScene.hpp>
 
-#include <mock/MockState.hpp>
 #include <mock/MockScene.hpp>
 
 #include <cengine/routing/SceneRepository.hpp>
@@ -12,23 +10,14 @@
 using namespace cengine::core;
 using namespace cengine::routing;
 
+// O repositório é puro provisionamento (task 13): factories, instanciação
+// lazy, cache e unload. A máquina de estados é testada no RouterInMemoryTest.
 class SceneRepositoryTest : public ::testing::Test {
 protected:
-    std::unique_ptr<MockState> initialState;
     std::unique_ptr<SceneRepository> sceneRepository;
 
     void SetUp() override {
-        initialState = std::make_unique<MockState>();
-
-        EXPECT_CALL(*initialState, clone())
-            .WillOnce(::testing::Return(std::make_unique<MockState>()))
-            .WillOnce(::testing::Return(std::make_unique<MockState>()));
-
-        // Define o comportamento dos métodos getCode e getName para evitar erros de mock
-        EXPECT_CALL(*initialState, getCode()).WillRepeatedly(::testing::Return("InitialStateCode"));
-        EXPECT_CALL(*initialState, getName()).WillRepeatedly(::testing::Return("InitialStateName"));
-
-        sceneRepository = std::make_unique<SceneRepository>(std::move(initialState));
+        sceneRepository = std::make_unique<SceneRepository>();
     }
 };
 
@@ -142,71 +131,4 @@ TEST_F(SceneRepositoryTest, UnloadAllRemovesAllScenes) {
 
     ASSERT_EQ(factory1CallCount, 2);
     ASSERT_EQ(factory2CallCount, 2);
-}
-
-// Teste: persisteCurrentState deve clonar m_nextState para m_currentState.
-TEST_F(SceneRepositoryTest, PersistCurrentStateClonesNextState) {
-    auto newStateForNext = std::make_unique<MockState>();
-
-    // 1. Move o novo estado para o repositório.
-    sceneRepository->persistNextState(std::move(newStateForNext));
-
-    // 2. Obtém uma referência ao objeto que agora está em m_nextState
-    IState& nextStateRef = sceneRepository->getNextStateGame();
-
-    // 3. Define a única expectativa de chamada que realmente acontecerá
-    EXPECT_CALL(static_cast<MockState&>(nextStateRef), clone())
-        .WillOnce(::testing::Return(std::make_unique<MockState>()));
-
-    // 4. Chama o método que irá disparar o clone()
-    sceneRepository->persisteCurrentState();
-}
-
-// Teste: persistNextState deve mover a propriedade de unique_ptr.
-TEST_F(SceneRepositoryTest, PersistNextStateMovesNewState) {
-    auto originalNextState = &sceneRepository->getNextStateGame();
-
-    auto brandNewState = std::make_unique<MockState>();
-    auto brandNewStatePtr = brandNewState.get();
-
-    // Persiste o novo estado movendo-o para a propriedade interna
-    sceneRepository->persistNextState(std::move(brandNewState));
-
-    // Verifica se a propriedade interna agora aponta para o novo objeto
-    ASSERT_EQ(&sceneRepository->getNextStateGame(), brandNewStatePtr);
-    // E se a propriedade anterior não é mais a mesma
-    ASSERT_NE(&sceneRepository->getNextStateGame(), originalNextState);
-}
-
-
-// Teste: hasPendingStateChange deve retornar true se os códigos de estado forem diferentes.
-TEST_F(SceneRepositoryTest, HasPendingStateChangeReturnsTrueIfCodesDifferent) {
-    auto nextStateMock = std::make_unique<MockState>();
-
-    // Define o comportamento de getCode() para os estados
-    EXPECT_CALL(static_cast<MockState&>(sceneRepository->getCurrentStateGame()), getCode())
-        .WillOnce(::testing::Return("SomeCode"));
-    EXPECT_CALL(*nextStateMock, getCode()).WillOnce(::testing::Return("DifferentCode"));
-
-    // Persiste o novo estado
-    sceneRepository->persistNextState(std::move(nextStateMock));
-
-    // A função deve retornar true porque os códigos são diferentes
-    EXPECT_TRUE(sceneRepository->hasPendingStateChange());
-}
-
-// Teste: hasPendingStateChange deve retornar false se os códigos de estado forem iguais.
-TEST_F(SceneRepositoryTest, HasPendingStateChangeReturnsFalseIfCodesSame) {
-    auto nextStateMock = std::make_unique<MockState>();
-
-    // Define o comportamento de getCode() para os estados
-    EXPECT_CALL(static_cast<MockState&>(sceneRepository->getCurrentStateGame()), getCode())
-        .WillOnce(::testing::Return("SameCode"));
-    EXPECT_CALL(*nextStateMock, getCode()).WillOnce(::testing::Return("SameCode"));
-
-    // Persiste o novo estado
-    sceneRepository->persistNextState(std::move(nextStateMock));
-
-    // A função deve retornar false porque os códigos são os mesmos
-    EXPECT_FALSE(sceneRepository->hasPendingStateChange());
 }

--- a/tests/routing/integration/SceneLifetimeTest.cpp
+++ b/tests/routing/integration/SceneLifetimeTest.cpp
@@ -10,32 +10,19 @@
 #include "gtest/gtest.h"
 
 #include <memory>
-#include <string>
 #include <utility>
 
 #include <cengine/core/IScene.hpp>
-#include <cengine/routing/IState.hpp>
 #include <cengine/routing/SceneRepository.hpp>
 #include <cengine/routing/RouterInMemory.hpp>
 #include <cengine/routing/GameManager.hpp>
+
+#include <mock/FakeState.hpp>
 
 using namespace cengine::core;
 using namespace cengine::routing;
 
 namespace {
-
-class FakeState final : public IState {
-    std::string m_code;
-
-public:
-    explicit FakeState(std::string code) : m_code(std::move(code)) {}
-
-    [[nodiscard]] std::string getCode() const override { return m_code; }
-    [[nodiscard]] std::string getName() const override { return m_code; }
-    [[nodiscard]] std::unique_ptr<IState> clone() const override {
-        return std::make_unique<FakeState>(m_code);
-    }
-};
 
 // Cena que rastreia seu tempo de vida (contador de instâncias vivas), quantas
 // vezes foi ativada (onEnter) e se seu onExit() foi chamado. Permite provar que
@@ -69,12 +56,14 @@ protected:
     int onEnterCountA{0};
     int onEnterCountB{0};
 
-    std::shared_ptr<SceneRepository> repository;
     std::shared_ptr<RouterInMemory> router;
     std::unique_ptr<GameManager> gameManager;
 
     void SetUp() override {
-        repository = std::make_shared<SceneRepository>(std::make_unique<FakeState>("A"));
+        // Fiação recomendada pós-task 13: o jogo registra as factories e
+        // TRANSFERE a posse do repositório ao router — nenhuma referência
+        // externa sobra para descarregar cenas por fora da navegação.
+        auto repository = std::make_unique<SceneRepository>();
         repository->registerFactory("A", [this]() {
             return std::make_unique<TrackedScene>(&liveA, &onExitCalledA, &onEnterCountA);
         });
@@ -82,7 +71,8 @@ protected:
             return std::make_unique<TrackedScene>(&liveB, &onExitCalledB, &onEnterCountB);
         });
 
-        router = std::make_shared<RouterInMemory>(repository);
+        router = std::make_shared<RouterInMemory>(
+            std::move(repository), std::make_unique<FakeState>("A"));
         gameManager = std::make_unique<GameManager>(router);
     }
 };
@@ -137,4 +127,30 @@ TEST_F(SceneLifetimeTest, NavigatingBackReactivatesScene) {
     EXPECT_EQ(onEnterCountA, 2);
     EXPECT_EQ(liveA, 1);
     EXPECT_EQ(liveB, 0); // B foi descarregada na volta
+}
+
+// Critério de aceite da task 13 (achado do review do PR #11): o caminho
+// SUPORTADO para descartar/recriar a cena do estado ativo é requestState com o
+// mesmo código — o commit descarrega a instância antiga e a próxima iteração
+// recria E reativa a cena (onEnter roda na instância nova). Eviction por fora
+// da navegação deixou de ser possível por construção: o router é o único dono
+// do repositório.
+TEST_F(SceneLifetimeTest, RequestingCurrentStateReloadsAndReactivatesScene) {
+    // Ativa A.
+    gameManager->onEnter();
+    ASSERT_EQ(liveA, 1);
+    ASSERT_EQ(onEnterCountA, 1);
+
+    // Reload deliberado: pedir o próprio estado "A".
+    router->requestState(std::make_unique<FakeState>("A"));
+    ASSERT_TRUE(router->hasPendingStateChange());
+
+    gameManager->onExit();
+    EXPECT_TRUE(onExitCalledA);  // a instância antiga recebeu onExit
+    EXPECT_EQ(liveA, 0);         // e foi destruída no commit
+
+    // A próxima iteração recria a cena via factory e a REATIVA.
+    gameManager->onEnter();
+    EXPECT_EQ(liveA, 1);
+    EXPECT_EQ(onEnterCountA, 2);
 }


### PR DESCRIPTION
## Resumo

Executa a **task 13** (`.ai/task/13-router-repository-responsibilities.md`): separa as responsabilidades que estavam misturadas entre `RouterInMemory` (antes um pass-through puro) e `SceneRepository` (antes com dois papéis). Fecha o ciclo **0.2.0** junto do PR #11.

**BREAKING CHANGE** — a porta `IRouter` e o `GameManager` ficam **inalterados**; quebra a fiação de montagem (`main`) e as interfaces `ISceneRepository`/`IState`.

## Divisão de responsabilidades

| Peça | Antes | Depois |
|------|-------|--------|
| `RouterInMemory` | delegação 1:1 ao repositório | **dono da máquina de estados** (`m_currentState`/`m_nextState`) e da política de unload no commit |
| `ISceneRepository` | cache de cenas **+** par de estados atual/próximo | **provedor puro**: `registerFactory` / `getScene` / `unloadScene` / `unloadAll` |

- `hasPendingStateChange()` existe num lugar só: `m_nextState != nullptr` (nada de comparar códigos).
- Os nomes com semântica invertida (`persisteCurrentState`, `getCurrentStateGame`, `getNextStateGame`, `persistNextState`) morreram com a interface.
- `IState` perde `clone()` — estados são movidos por `unique_ptr`, sem padrão Prototype (fecha de carona a opção 3 da task 10).

## Posse exclusiva do repositório (resolve o achado do PR #11)

O router recebe o repositório por **`unique_ptr`**: o jogo registra as factories e transfere a posse. Não sobra referência externa para descarregar a cena ativa por fora da navegação — o cenário de eviction apontado pelo review do PR #11 fica **impossível por construção**.

A via suportada de reload ganhou semântica própria: `requestState()` com o código do estado **atual** agora é troca válida (descarrega, recria e **reativa** a cena). Antes era indistinguível de "nada pendente".

## Nova montagem

```cpp
auto repository = std::make_unique<routing::SceneRepository>();
repository->registerFactory("main_menu", [] { return std::make_unique<MenuScene>(); });

auto router = std::make_shared<routing::RouterInMemory>(
    std::move(repository), std::make_unique<MyState>("main_menu"));
auto gameManager = std::make_unique<routing::GameManager>(router);
```

README (Minimal assembly) atualizado.

## Testes (29/29 ✅, CI verde nos 3 jobs)

- `RouterInMemoryTest` reescrito: deixa de testar delegação pass-through e testa a **máquina de estados real** (7 testes: estado inicial, agendamento sem efetivar, reload de mesmo código, commit promove + descarrega, commit sem pendência é no-op, resolução de cena).
- `SceneRepositoryTest` só provisionamento (6 testes; os 4 de estado migraram de conceito para o router).
- Novo teste de integração `SceneLifetimeTest.RequestingCurrentStateReloadsAndReactivatesScene` — cobre o critério de aceite do eviction (via ASan no CI).
- `FakeState` compartilhado em `tests/mock/`; `MockState`/`MockSceneRepository` enxugados.

## Impacto no consumidor (8Puzzle)

Ao consumir a 0.2.0: `GameRouter` passa a envolver o `IRouter` (não o repositório); o `main.cpp` registra factories e move a posse para o router junto do estado inicial; remover os `clone()` dos `StateGame`. Registrado como pendência na task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
