### PR TITLE
chore(release): CHANGELOG e bump para 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to CEngine are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-07-08
+
+API design cycle (tasks 12–13 of the [improvement plan](.ai/task/README.md)):
+leaner ports and single-owner responsibilities in the routing module.
+
+> **Breaking release.** The `IScene`, `IState` and `ISceneRepository` contracts
+> changed, and so did the `RouterInMemory` wiring. See _Migrating from 0.1.0_
+> below.
+
+### Changed
+
+- **`IScene` slimmed to 4 methods** (`onEnter` / `input` / `draw` / `onExit`):
+  the activation bookkeeping pair `onEnterExecuted()` / `isOnEnterExecuted()`
+  was removed from the port. The "runs exactly once per activation" guarantee
+  is now enforced by `cengine::routing::GameManager` (tracked by state code,
+  reset when a navigation is committed) — scenes no longer carry a flag.
+- **`RouterInMemory` owns the state machine**: the current/next state pair
+  moved from the repository into the router, and `hasPendingStateChange()` now
+  means "a next state is scheduled" (null check) instead of a code comparison.
+- **`RouterInMemory` takes exclusive ownership of the repository**: the
+  constructor now receives `unique_ptr<ISceneRepository>` plus the initial
+  state. No external reference can unload scenes behind the navigation cycle
+  (closes the active-scene-eviction hole found in review).
+- **Requesting the current state's code is now a valid transition** — a
+  deliberate reload: the scene is unloaded, recreated and re-entered.
+  Previously this was indistinguishable from "no pending change".
+- **`ISceneRepository` is a pure scene provider**: `registerFactory` /
+  `getScene` / `unloadScene` / `unloadAll`. The state accessors
+  (`getCurrentStateGame`, `getNextStateGame`, `persisteCurrentState`,
+  `persistNextState`, `hasPendingStateChange`) were removed with the
+  responsibility.
+
+### Removed
+
+- **`IState::clone()`** — states are moved (`unique_ptr`) into the router; the
+  Prototype pattern is no longer required from consumers.
+
+### Added
+
+- **Integration regression tests**: navigating A→B→A re-activates the returning
+  scene, and requesting the current state reloads + re-activates it (both meant
+  to run under the ASan CI job).
+
+### Migrating from 0.1.0
+
+- Remove `onEnterExecuted()` / `isOnEnterExecuted()` (and the backing flag)
+  from your `IScene` implementations.
+- Remove `clone()` from your `IState` implementations.
+- Update the assembly: register factories on the repository, then **move** it
+  into the router along with the initial state:
+  ```cpp
+  auto repository = std::make_unique<routing::SceneRepository>();
+  repository->registerFactory("main_menu", [] { return std::make_unique<MenuScene>(); });
+
+  auto router = std::make_shared<routing::RouterInMemory>(
+      std::move(repository), std::make_unique<MyState>("main_menu"));
+  auto gameManager = std::make_unique<routing::GameManager>(router);
+  ```
+- If your game kept a reference to the repository for domain navigation (e.g.,
+  a facade), wrap the `IRouter` instead — the repository is engine-internal
+  after the move.
+
 ## [0.1.0] - 2026-07-06
 
 First release after the architecture overhaul guided by the improvement plan in
@@ -90,5 +152,6 @@ routing as an **opt-in module**.
 - Initial single-target (`cengine_lib`) engine: game loop, scene/state
   management, and in-memory router.
 
+[0.2.0]: https://github.com/mrmarmitt/cengine/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/mrmarmitt/cengine/compare/0.0.1...0.1.0
 [0.0.1]: https://github.com/mrmarmitt/cengine/releases/tag/0.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(cengine VERSION 0.1.0 LANGUAGES CXX)
+project(cengine VERSION 0.2.0 LANGUAGES CXX)
 
 # Define padrão do projeto
 set(CMAKE_CXX_STANDARD 23)


### PR DESCRIPTION
Fecha o ciclo 0.2.0 de design de API (PRs #11 e #12 / tasks 12 e 13):

- `IScene` enxuta (4 metodos; contabilidade de ativacao no `GameManager`)
- Router dono da maquina de estados e do repositorio (posse exclusiva)
- `requestState` com o codigo atual = reload deliberado
- `ISceneRepository` provedor puro; `IState` sem `clone()`

Inclui entrada completa no CHANGELOG (Keep a Changelog) com guia de migracao a partir da 0.1.0, e bump do `project(VERSION)` para 0.2.0.

Apos o merge: criar a tag `0.2.0` no commit de merge (mesmo fluxo da 0.1.0).

29/29 testes passando com a versao bumpada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)