### PR TITLE
feat(core)!: tempo no loop — update(dt) com fixed timestep (task 14)

### DIFF
--- a/.ai/decisions/0001-modular-core-vs-modules.md
+++ b/.ai/decisions/0001-modular-core-vs-modules.md
@@ -116,10 +116,11 @@ Nenhum se aplica hoje → monorepo, **projetado para ser extraível**.
 ## Notas de implementação
 
 - **Física tem uma sutileza:** costuma exigir *fixed timestep* (separar
-  `update(dt)` de `render()`). Hoje o loop (`EngineManager::run()`) não tem
-  conceito de tempo/`dt`. Física pode, portanto, forçar o **core a evoluir o
-  contrato do loop** — diferente de roteamento, que não toca no core. Não
-  resolver agora, mas não fechar o design do loop de um jeito que impeça isso.
+  `update(dt)` de `render()`). ~~Hoje o loop (`EngineManager::run()`) não tem
+  conceito de tempo/`dt`.~~ **Resolvido na
+  [Tarefa 14](../task/14-time-in-the-loop.md)**: o loop mede tempo com relógio
+  monotônico e executa `update(dt)` em passos fixos (acumulador + teto
+  anti-espiral) — o contrato que um futuro `cengine::physics` consome.
 - `IState` (máquina de estados) é considerado conceito de **roteamento**, não de
   core — vai para `cengine::routing`.
 

--- a/.ai/task/14-time-in-the-loop.md
+++ b/.ai/task/14-time-in-the-loop.md
@@ -1,6 +1,6 @@
 # 14 — Tempo no loop: `update(dt)` separado de `render()`
 
-- **Status:** todo
+- **Status:** done ✅ (opção B, 2026-07-08, branch `feature/14-time-in-the-loop`)
 - **Prioridade:** 🔴 Alta (arquitetural — a maior lacuna do core)
 - **Categoria:** Arquitetura / core
 - **Depende de:** 12 e 13 (ciclo 0.2.0 fechado; portas estáveis)
@@ -175,15 +175,47 @@ B + `render(alpha)` com estado anterior/atual interpolado.
 
 ## Critérios de aceite
 
-- [ ] `EngineManager::run()` mede tempo com relógio monotônico e executa
+- [x] `EngineManager::run()` mede tempo com relógio monotônico e executa
       `update(dt)` em passos fixos (acumulador + clamp anti-espiral).
-- [ ] `dt` tipado com `std::chrono` na API pública (nada de `double` cru).
-- [ ] Ordem do frame coberta por teste de call-log, incluindo os casos
+- [x] `dt` tipado com `std::chrono` na API pública (nada de `double` cru).
+- [x] Ordem do frame coberta por teste de call-log, incluindo os casos
       "0 updates" e "N updates com dt idêntico".
-- [ ] Fonte de tempo injetável (testes não dependem de sleep/tempo real).
-- [ ] `kFixedDt` configurável na construção; defaults documentados.
-- [ ] Portas atualizadas com Doxygen do novo contrato; ADR 0001 anotado.
-- [ ] Suíte verde (CI 3 jobs, incluindo ASan).
+- [x] Fonte de tempo injetável (testes não dependem de sleep/tempo real).
+- [x] `kFixedDt` configurável na construção; defaults documentados.
+- [x] Portas atualizadas com Doxygen do novo contrato; ADR 0001 anotado.
+- [x] Suíte verde (CI 3 jobs, incluindo ASan).
+
+## Resultado da execução
+
+Executada a **opção B** (fixed timestep com acumulador), com as decisões de
+design da seção anterior:
+
+- **`core/Time.hpp`** novo: `using Seconds = std::chrono::duration<double>;`.
+- **`IScene::update(Seconds)`** e **`IGameManager::update(Seconds)`** novos
+  (Doxygen com o contrato "0..N chamadas por quadro, mesmo dt");
+  `routing::GameManager::update` delega à cena atual.
+- **`EngineManager`**: construtor ganhou `fixedDt` (default `kDefaultFixedDt`
+  = 1/60 s), `maxFrameTime` (default 250 ms) e `clockNow` injetável (default
+  `steady_clock::now` — `std::function<TimePoint()>`, a forma mais barata).
+  Configuração não-positiva lança `std::invalid_argument` (um `fixedDt <= 0`
+  travaria o loop interno). `run()` implementa acumulador + teto anti-espiral.
+- **Testes (35/35)** — 6 novos:
+  - unidade: quadro longo → N updates com o MESMO dt; quadro curto → 0 updates
+    (render acontece mesmo assim); clamp do frameTime; construção inválida
+    lança; `GameManager::update` repassa o dt à cena.
+  - integração (call-log): o acumulador carrega o resto entre quadros
+    (25 ms/quadro com passo de 10 ms → 2 updates no quadro 1, 3 no quadro 2),
+    na ordem `input → update* → render`.
+  - Os fixtures existentes injetam relógio congelado (frameTime = 0) — os
+    call-logs antigos continuam válidos e determinísticos.
+- README (seção "The frame and time") e ADR 0001 (nota resolvida) atualizados.
+
+## Pendências fora do escopo (atualizado na execução)
+
+- **8Puzzle** (ao consumir a 0.3.0): cenas ganham `update(Seconds) {}`;
+  oportunidade: cronômetro de partida no `GameScene` via dt.
+- Throttling/cap de FPS (sleep/vsync) — decisão de plataforma, task futura.
+- Interpolação de render (opção C) — quando houver consumidor gráfico.
 
 ## Riscos
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ the switch is committed at the end of the frame (`onExit`). Requesting the
 and re-entered). Routing to the `cengine::routing::kExitStateCode` state stops
 the loop.
 
+### The frame and time
+
+Each frame runs `input()` → `update(dt)` → `draw()` on the active scene. The
+loop uses a **fixed timestep** ("fix your timestep"): frame time is measured
+with a monotonic clock and consumed in constant `dt` steps — `update` runs
+**0..N times per frame, always with the same `dt`** (default 1/60 s,
+configurable in the `EngineManager` constructor). Put simulation (animations,
+timers, physics) in `update(dt)`; never measure time inside a scene.
+
 The public headers carry Doxygen comments describing each contract — start from
 [`IScene`](core/include/cengine/core/IScene.hpp) and
 [`IGameManager`](core/include/cengine/core/IGameManager.hpp).

--- a/core/include/cengine/core/EngineManager.hpp
+++ b/core/include/cengine/core/EngineManager.hpp
@@ -1,14 +1,17 @@
 #pragma once
 
+#include <chrono>
+#include <functional>
 #include <memory>
 
 #include <cengine/core/IGameManager.hpp>
 #include <cengine/core/IWindowManager.hpp>
+#include <cengine/core/Time.hpp>
 
 namespace cengine::core {
 
 /**
- * @brief O coração da engine: o game loop.
+ * @brief O coração da engine: o game loop, com *fixed timestep*.
  *
  * É a única classe concreta do `core`. Recebe por injeção de dependência um
  * `IWindowManager` (a plataforma gráfica) e um `IGameManager` (as regras/telas
@@ -16,8 +19,21 @@ namespace cengine::core {
  * para sair.
  *
  * Cada iteração executa: `window.update()` → `game.onEnter()` → `game.input()`
- * → `game.render()` → `game.onExit()`, e para quando `game.shouldExit()` retorna
- * true — encerrando com `cleanup()`.
+ * → `game.update(dt)` (0..N vezes) → `game.render()` → `game.onExit()`, e para
+ * quando `game.shouldExit()` retorna true — encerrando com `cleanup()`.
+ *
+ * ## Tempo (padrão "fix your timestep")
+ * O tempo do quadro é medido com relógio monotônico e acumulado; a simulação
+ * avança em passos FIXOS de `fixedDt` (default 1/60 s): num quadro curto,
+ * `update` pode não rodar; num quadro longo, roda várias vezes — sempre com o
+ * mesmo dt, o que mantém a simulação determinística e estável (pré-requisito
+ * de física). O tempo de quadro é limitado a `maxFrameTime` (default 250 ms)
+ * para evitar a espiral da morte (quadro lento → mais passos → quadro mais
+ * lento). Render não interpola entre passos (fora do escopo — ver task 14).
+ *
+ * A fonte de tempo é injetável (`clockNow`) para permitir testes
+ * determinísticos do loop, sem tempo real; o default é o relógio monotônico
+ * `std::chrono::steady_clock`.
  *
  * @code
  * cengine::core::EngineManager engine{
@@ -28,19 +44,30 @@ namespace cengine::core {
  * @endcode
  */
 class EngineManager {
-    void run();
-    std::unique_ptr<IWindowManager> m_windowManager;
-    std::unique_ptr<IGameManager> m_gameManager;
-    bool m_isRunning;
-
 public:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+    using ClockNowFn = std::function<TimePoint()>;
+
+    static constexpr Seconds kDefaultFixedDt{1.0 / 60.0};
+    static constexpr Seconds kDefaultMaxFrameTime{0.25};
+
     /**
      * @param windowManager plataforma gráfica (posse transferida à engine).
      * @param gameManager   regras/telas do jogo (posse transferida à engine).
+     * @param fixedDt       passo fixo da simulação (> 0; default 1/60 s).
+     * @param maxFrameTime  teto do tempo de quadro acumulável (> 0; default
+     *                      250 ms) — proteção contra a espiral da morte.
+     * @param clockNow      fonte de tempo (default: relógio monotônico).
+     * @throws std::invalid_argument se @p fixedDt ou @p maxFrameTime não for
+     *         positivo.
      */
     EngineManager(
         std::unique_ptr<IWindowManager> windowManager,
-        std::unique_ptr<IGameManager> gameManager);
+        std::unique_ptr<IGameManager> gameManager,
+        Seconds fixedDt = kDefaultFixedDt,
+        Seconds maxFrameTime = kDefaultMaxFrameTime,
+        ClockNowFn clockNow = Clock::now);
 
     ~EngineManager() = default;
 
@@ -49,6 +76,16 @@ public:
 
     /// Libera recursos do jogo e da janela. Invocado ao final de `start()`.
     void cleanup() const;
+
+private:
+    void run();
+
+    std::unique_ptr<IWindowManager> m_windowManager;
+    std::unique_ptr<IGameManager> m_gameManager;
+    Seconds m_fixedDt;
+    Seconds m_maxFrameTime;
+    ClockNowFn m_clockNow;
+    bool m_isRunning;
 };
 
 } // namespace cengine::core

--- a/core/include/cengine/core/IGameManager.hpp
+++ b/core/include/cengine/core/IGameManager.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cengine/core/Time.hpp>
+
 namespace cengine::core {
 
 /**
@@ -10,8 +12,9 @@ namespace cengine::core {
  * implementação `cengine::routing::GameManager`, que delega para o roteador).
  *
  * Os métodos abaixo são chamados a cada iteração do loop, na ordem:
- * `onEnter()` → `input()` → `render()` → `onExit()`, e por fim `shouldExit()`
- * decide se o loop continua. `cleanup()` roda uma vez, ao encerrar.
+ * `onEnter()` → `input()` → `update(dt)` (0..N vezes, passo fixo) →
+ * `render()` → `onExit()`, e por fim `shouldExit()` decide se o loop
+ * continua. `cleanup()` roda uma vez, ao encerrar.
  */
 class IGameManager {
 public:
@@ -27,6 +30,10 @@ public:
 
     /// Processa a entrada do usuário na cena atual.
     virtual void input() = 0;
+
+    /// Avança a simulação em @p dt. Contrato de *fixed timestep*: o loop chama
+    /// 0..N vezes por iteração, sempre com o MESMO dt (ver EngineManager).
+    virtual void update(Seconds dt) = 0;
 
     /// Trata a saída da cena atual e efetiva uma eventual troca de estado.
     virtual void onExit() = 0;

--- a/core/include/cengine/core/IScene.hpp
+++ b/core/include/cengine/core/IScene.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cengine/core/Time.hpp>
+
 namespace cengine::core {
 
 /**
@@ -12,7 +14,8 @@ namespace cengine::core {
  * ## Ciclo de vida (por iteração do game loop)
  * A cada volta do loop o gerenciador de jogo chama, nesta ordem:
  * `onEnter()` (só na primeira vez em que a cena é ativada) → `input()` →
- * `draw()`. Ao trocar de cena, a cena que sai recebe `onExit()`.
+ * `update(dt)` (0..N vezes, passo fixo) → `draw()`. Ao trocar de cena, a cena
+ * que sai recebe `onExit()`.
  *
  * A garantia de que `onEnter()` roda **uma única vez** por ativação é do
  * orquestrador (ex.: `cengine::routing::GameManager`), não da cena — a
@@ -30,10 +33,16 @@ public:
     /// Chamado uma vez por ativação, antes do primeiro `input()`/`draw()`.
     virtual void onEnter() = 0;
 
+    /// Avança a simulação da cena em @p dt (animações, timers, física...).
+    /// Contrato de *fixed timestep*: chamado **0..N vezes por iteração** do
+    /// loop, sempre com o MESMO dt — a cena não deve assumir 1 chamada por
+    /// quadro nem medir tempo por conta própria.
+    virtual void update(Seconds dt) = 0;
+
     /// Desenha o quadro atual. Chamado toda iteração enquanto a cena está ativa.
     virtual void draw() = 0;
 
-    /// Processa entrada do usuário. Chamado toda iteração, antes de `draw()`.
+    /// Processa entrada do usuário. Chamado toda iteração, antes de `update()`.
     virtual void input() = 0;
 
     /// Finalização da cena (liberar recursos). Chamado ao sair/trocar de cena.

--- a/core/include/cengine/core/Time.hpp
+++ b/core/include/cengine/core/Time.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <chrono>
+
+namespace cengine::core {
+
+/// Duração em segundos (ponto flutuante) usada no contrato de tempo do loop.
+/// `std::chrono` de ponta a ponta: nada de `double` cru com unidade ambígua.
+using Seconds = std::chrono::duration<double>;
+
+} // namespace cengine::core

--- a/core/src/EngineManager.cpp
+++ b/core/src/EngineManager.cpp
@@ -1,11 +1,26 @@
 #include <cengine/core/EngineManager.hpp>
 
+#include <stdexcept>
+#include <utility>
+
 namespace cengine::core {
 
 EngineManager::EngineManager(std::unique_ptr<IWindowManager> windowManager,
-                             std::unique_ptr<IGameManager> gameManager) : m_windowManager(std::move(windowManager)),
-                                                                         m_gameManager(std::move(gameManager)),
-                                                                         m_isRunning(false) {
+                             std::unique_ptr<IGameManager> gameManager,
+                             const Seconds fixedDt,
+                             const Seconds maxFrameTime,
+                             ClockNowFn clockNow) : m_windowManager(std::move(windowManager)),
+                                                    m_gameManager(std::move(gameManager)),
+                                                    m_fixedDt(fixedDt),
+                                                    m_maxFrameTime(maxFrameTime),
+                                                    m_clockNow(std::move(clockNow)),
+                                                    m_isRunning(false) {
+    if (m_fixedDt <= Seconds{0}) {
+        throw std::invalid_argument("EngineManager: fixedDt must be positive");
+    }
+    if (m_maxFrameTime <= Seconds{0}) {
+        throw std::invalid_argument("EngineManager: maxFrameTime must be positive");
+    }
 }
 
 void EngineManager::start() {
@@ -28,11 +43,31 @@ void EngineManager::cleanup() const {
 }
 
 void EngineManager::run() {
+    TimePoint previous = m_clockNow();
+    Seconds accumulator{0};
+
     while (m_isRunning) {
+        const TimePoint now = m_clockNow();
+        Seconds frameTime = now - previous;
+        previous = now;
+
+        // Teto anti-espiral: um quadro muito lento não pode gerar passos de
+        // simulação suficientes para deixar o próximo quadro ainda mais lento.
+        if (frameTime > m_maxFrameTime) {
+            frameTime = m_maxFrameTime;
+        }
+
         m_windowManager->update();
 
         m_gameManager->onEnter();
         m_gameManager->input();
+
+        // Fixed timestep: consome o tempo acumulado em passos de dt constante
+        // (0..N chamadas por quadro; o resto fica para o próximo quadro).
+        for (accumulator += frameTime; accumulator >= m_fixedDt; accumulator -= m_fixedDt) {
+            m_gameManager->update(m_fixedDt);
+        }
+
         m_gameManager->render();
         m_gameManager->onExit();
 

--- a/modules/routing/include/cengine/routing/GameManager.hpp
+++ b/modules/routing/include/cengine/routing/GameManager.hpp
@@ -29,6 +29,7 @@ public:
     void onEnter() override;
     void render() override;
     void input() override;
+    void update(core::Seconds dt) override;
     void onExit() override;
 
     [[nodiscard]] bool shouldExit() const override;

--- a/modules/routing/src/GameManager.cpp
+++ b/modules/routing/src/GameManager.cpp
@@ -34,6 +34,12 @@ void GameManager::input() {
     scene.input();
 }
 
+void GameManager::update(const core::Seconds dt) {
+    core::IScene& scene = m_routerService->currentScene();
+
+    scene.update(dt);
+}
+
 void GameManager::onExit() {
     if (!m_routerService->hasPendingStateChange()) {
         return;

--- a/tests/core/EngineManagerTest.cpp
+++ b/tests/core/EngineManagerTest.cpp
@@ -1,6 +1,10 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+
 #include <mock/MockWindowManager.hpp>
 #include <mock/MockGameManager.hpp>
 
@@ -32,10 +36,16 @@ protected:
         m_capturedWindowManager = m_mockWindowManager.get();
         m_capturedGameManager = m_mockGameManager.get();
 
-        // Inicializa a classe EngineManager, transferindo a propriedade dos mocks
+        // Inicializa a classe EngineManager, transferindo a propriedade dos mocks.
+        // Relógio CONGELADO: frameTime = 0 em todo quadro -> nenhum passo de
+        // update; os testes de contagem de passos ficam nas suítes de fixed
+        // timestep abaixo.
         m_engineManager = std::make_unique<EngineManager>(
             std::move(m_mockWindowManager),
-            std::move(m_mockGameManager));
+            std::move(m_mockGameManager),
+            EngineManager::kDefaultFixedDt,
+            EngineManager::kDefaultMaxFrameTime,
+            [] { return EngineManager::TimePoint{}; });
     }
 };
 
@@ -46,10 +56,13 @@ TEST_F(EngineManagerTest, Start_InitializesWindowAndRunsLoop) {
     // 1. O método start() chama windowManager->init().
     EXPECT_CALL(*m_capturedWindowManager, init()).Times(1);
 
-    // 2. O loop 'run' começa.
+    // 2. O loop 'run' começa. Com o relógio congelado, nenhum tempo acumula:
+    //    o quadro "curto" tem ZERO passos de update — e o render acontece
+    //    mesmo assim.
     EXPECT_CALL(*m_capturedWindowManager, update()).Times(1);
     EXPECT_CALL(*m_capturedGameManager, onEnter()).Times(1);
     EXPECT_CALL(*m_capturedGameManager, input()).Times(1);
+    EXPECT_CALL(*m_capturedGameManager, update(testing::_)).Times(0);
     EXPECT_CALL(*m_capturedGameManager, render()).Times(1);
     EXPECT_CALL(*m_capturedGameManager, onExit()).Times(1);
 
@@ -73,4 +86,91 @@ TEST_F(EngineManagerTest, Cleanup_CallsDependenciesCleanup) {
     EXPECT_CALL(*m_capturedWindowManager, cleanup()).Times(1);
 
     m_engineManager->cleanup();
+}
+
+// ------------------------------------------------------------------
+// Fixed timestep (task 14): contagem de passos de update por quadro,
+// com relógio fake que avança um passo controlado a cada consulta.
+// ------------------------------------------------------------------
+class EngineManagerFixedTimestepTest : public ::testing::Test {
+protected:
+    MockWindowManager* m_windowManager{nullptr};
+    MockGameManager* m_gameManager{nullptr};
+    std::unique_ptr<EngineManager> m_engineManager;
+
+    // Monta a engine com um relógio que avança @p clockStep a cada chamada
+    // (uma consulta antes do loop + uma por quadro -> frameTime == clockStep).
+    void makeEngine(const Seconds fixedDt, const Seconds maxFrameTime, const Seconds clockStep) {
+        auto windowManager = std::make_unique<MockWindowManager>();
+        auto gameManager = std::make_unique<MockGameManager>();
+        m_windowManager = windowManager.get();
+        m_gameManager = gameManager.get();
+
+        auto now = std::make_shared<EngineManager::TimePoint>();
+        m_engineManager = std::make_unique<EngineManager>(
+            std::move(windowManager),
+            std::move(gameManager),
+            fixedDt,
+            maxFrameTime,
+            [now, clockStep] {
+                *now += std::chrono::duration_cast<EngineManager::Clock::duration>(clockStep);
+                return *now;
+            });
+
+        // Fora do foco destes testes: um quadro só, sem InSequence.
+        EXPECT_CALL(*m_windowManager, init()).Times(1);
+        EXPECT_CALL(*m_windowManager, update()).Times(1);
+        EXPECT_CALL(*m_windowManager, cleanup()).Times(1);
+        EXPECT_CALL(*m_gameManager, onEnter()).Times(1);
+        EXPECT_CALL(*m_gameManager, input()).Times(1);
+        EXPECT_CALL(*m_gameManager, render()).Times(1);
+        EXPECT_CALL(*m_gameManager, onExit()).Times(1);
+        EXPECT_CALL(*m_gameManager, cleanup()).Times(1);
+        EXPECT_CALL(*m_gameManager, shouldExit()).WillOnce(testing::Return(true));
+    }
+};
+
+// Quadro longo: 35 ms com passo de 10 ms -> exatamente 3 updates, todos com o
+// MESMO dt fixo (os 5 ms restantes ficam acumulados para o próximo quadro).
+TEST_F(EngineManagerFixedTimestepTest, LongFrameRunsMultipleUpdatesWithSameFixedDt) {
+    constexpr Seconds fixedDt{0.010};
+    makeEngine(fixedDt, EngineManager::kDefaultMaxFrameTime, Seconds{0.035});
+
+    EXPECT_CALL(*m_gameManager, update(fixedDt)).Times(3);
+
+    m_engineManager->start();
+}
+
+// Quadro mais curto que o passo fixo: nenhum update, mas o quadro (render)
+// acontece normalmente.
+TEST_F(EngineManagerFixedTimestepTest, ShortFrameRunsZeroUpdates) {
+    makeEngine(Seconds{0.010}, EngineManager::kDefaultMaxFrameTime, Seconds{0.004});
+
+    EXPECT_CALL(*m_gameManager, update(testing::_)).Times(0);
+
+    m_engineManager->start();
+}
+
+// Teto anti-espiral: um quadro de 1 s com teto de 100 ms e passo de 50 ms
+// gera apenas 2 updates (o excedente é descartado, não acumulado).
+TEST_F(EngineManagerFixedTimestepTest, FrameTimeIsClampedToMaxFrameTime) {
+    constexpr Seconds fixedDt{0.050};
+    makeEngine(fixedDt, Seconds{0.100}, Seconds{1.0});
+
+    EXPECT_CALL(*m_gameManager, update(fixedDt)).Times(2);
+
+    m_engineManager->start();
+}
+
+// Configuração inválida deve falhar na construção, não travar o loop.
+TEST(EngineManagerConstructionTest, RejectsNonPositiveFixedDt) {
+    EXPECT_THROW(EngineManager(std::make_unique<MockWindowManager>(),
+                               std::make_unique<MockGameManager>(),
+                               Seconds{0}),
+                 std::invalid_argument);
+    EXPECT_THROW(EngineManager(std::make_unique<MockWindowManager>(),
+                               std::make_unique<MockGameManager>(),
+                               EngineManager::kDefaultFixedDt,
+                               Seconds{-1.0}),
+                 std::invalid_argument);
 }

--- a/tests/core/integration/EngineManagerIntegrationTest.cpp
+++ b/tests/core/integration/EngineManagerIntegrationTest.cpp
@@ -30,10 +30,15 @@ protected:
         m_rawWindowManager = m_fakeWindowManager.get();
         m_rawGameManager = m_fakeGameManager.get();
 
-        // Inicializa o EngineManager com as implementações "fake"
+        // Inicializa o EngineManager com as implementações "fake" e relógio
+        // CONGELADO (frameTime = 0 -> nenhum passo de update); a contagem de
+        // passos é coberta pelo teste de fixed timestep abaixo.
         m_engineManager = std::make_unique<EngineManager>(
             std::move(m_fakeWindowManager),
-            std::move(m_fakeGameManager)
+            std::move(m_fakeGameManager),
+            EngineManager::kDefaultFixedDt,
+            EngineManager::kDefaultMaxFrameTime,
+            [] { return EngineManager::TimePoint{}; }
         );
     }
 };
@@ -89,4 +94,38 @@ TEST_F(EngineManagerIntegrationTest, Start_ExecutesLoopCorrectlyForMultipleItera
     ASSERT_EQ(m_rawGameManager->callLog[6], "render");
     ASSERT_EQ(m_rawGameManager->callLog[7], "onExit");
     ASSERT_EQ(m_rawGameManager->callLog[8], "cleanup");
+}
+
+// Fixed timestep de ponta a ponta (task 14): com relógio que avança 25 ms por
+// quadro e passo fixo de 10 ms, o quadro 1 consome 2 passos (sobram 5 ms) e o
+// quadro 2 consome 3 (5 + 25 = 30 ms) — na ordem input -> update* -> render.
+TEST(EngineManagerFixedTimestepIntegrationTest, AccumulatorCarriesRemainderAcrossFrames) {
+    auto fakeWindowManager = std::make_unique<FakeWindowManager>();
+    auto fakeGameManager = std::make_unique<FakeGameManager>();
+    FakeGameManager* rawGameManager = fakeGameManager.get();
+    rawGameManager->maxRuns = 2;
+
+    constexpr Seconds kFixedDt{0.010};
+    auto now = std::make_shared<EngineManager::TimePoint>();
+
+    EngineManager engineManager{
+        std::move(fakeWindowManager),
+        std::move(fakeGameManager),
+        kFixedDt,
+        EngineManager::kDefaultMaxFrameTime,
+        [now] {
+            *now += std::chrono::milliseconds{25};
+            return *now;
+        }};
+
+    engineManager.start();
+
+    const std::vector<std::string> expected{
+        "onEnter", "input", "update", "update", "render", "onExit",                // quadro 1: 25 ms -> 2 passos
+        "onEnter", "input", "update", "update", "update", "render", "onExit",     // quadro 2: 5 + 25 ms -> 3 passos
+        "cleanup"};
+    ASSERT_EQ(rawGameManager->callLog, expected);
+
+    // Todos os passos usam o MESMO dt fixo.
+    ASSERT_EQ(rawGameManager->lastDt, kFixedDt);
 }

--- a/tests/core/integration/FakeImplementations.hpp
+++ b/tests/core/integration/FakeImplementations.hpp
@@ -40,6 +40,7 @@ public:
     std::vector<std::string> callLog;
     int runCount = 0;
     int maxRuns = 1;
+    cengine::core::Seconds lastDt{0};
 
     void onEnter() override {
         runCount++;
@@ -52,6 +53,11 @@ public:
 
     void input() override {
         callLog.push_back("input");
+    }
+
+    void update(cengine::core::Seconds dt) override {
+        callLog.push_back("update");
+        lastDt = dt;
     }
 
     void onExit() override {

--- a/tests/mock/MockGameManager.hpp
+++ b/tests/mock/MockGameManager.hpp
@@ -10,6 +10,7 @@ public:
     MOCK_METHOD(void, onEnter, (), (override));
     MOCK_METHOD(void, render, (), (override));
     MOCK_METHOD(void, input, (), (override));
+    MOCK_METHOD(void, update, (cengine::core::Seconds), (override));
     MOCK_METHOD(void, onExit, (), (override));
     MOCK_METHOD(void, cleanup, (), (override));
 

--- a/tests/mock/MockScene.hpp
+++ b/tests/mock/MockScene.hpp
@@ -6,6 +6,7 @@
 class MockScene : public cengine::core::IScene {
 public:
     MOCK_METHOD(void, onEnter, (), (override));
+    MOCK_METHOD(void, update, (cengine::core::Seconds), (override));
     MOCK_METHOD(void, draw, (), (override));
     MOCK_METHOD(void, input, (), (override));
     MOCK_METHOD(void, onExit, (), (override));

--- a/tests/routing/GameManagerTest.cpp
+++ b/tests/routing/GameManagerTest.cpp
@@ -71,6 +71,15 @@ TEST_F(GameManagerTest, OnEnter_AfterCommittedNavigation_ReentersEvenWithSameSta
     m_gameManager->onEnter();
 }
 
+TEST_F(GameManagerTest, Update_ForwardsFixedDtToCurrentScene) {
+    constexpr cengine::core::Seconds dt{1.0 / 60.0};
+
+    EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
+    EXPECT_CALL(m_mockScene, update(dt)).Times(1);
+
+    m_gameManager->update(dt);
+}
+
 TEST_F(GameManagerTest, Render_CallsDrawOnCurrentScene) {
     EXPECT_CALL(*m_mockRouter, currentScene()).WillOnce(testing::ReturnRef(m_mockScene));
     EXPECT_CALL(m_mockScene, draw()).Times(1);

--- a/tests/routing/integration/SceneLifetimeTest.cpp
+++ b/tests/routing/integration/SceneLifetimeTest.cpp
@@ -40,6 +40,7 @@ public:
     ~TrackedScene() override { --(*m_liveCount); }
 
     void onEnter() override { ++(*m_onEnterCount); }
+    void update(Seconds) override {}
     void draw() override {}
     void input() override {}
     void onExit() override { *m_onExitCalled = true; }


### PR DESCRIPTION
## Resumo

Executa a **task 14** (`.ai/task/14-time-in-the-loop.md`): o loop ganha conceito de tempo — `update(dt)` com **fixed timestep** (padrão "fix your timestep"). Era a última lacuna estrutural do core apontada na avaliação de arquitetura e a nota pendente do ADR 0001; é o contrato que o futuro `cengine::physics` exige. Âncora do ciclo **0.3.0**.

**BREAKING CHANGE** — `IScene` e `IGameManager` ganham `update(Seconds dt)` puro; todo consumidor precisa implementá-lo (pode ser vazio).

## Problema

O loop girava sem tempo: velocidade máxima da CPU, sem fase de simulação. O 8Puzzle só funciona porque o `_getch` bloqueante "paceia" o loop por acidente — qualquer cena não-bloqueante viraria busy-loop, e física seria impossível (integração estável exige passos fixos).

## O que muda

**Contrato de tempo** (`core/Time.hpp` novo):
- `using Seconds = std::chrono::duration<double>` — `std::chrono` de ponta a ponta na API pública, sem `double` cru de unidade ambígua.
- `IScene::update(Seconds)` / `IGameManager::update(Seconds)`: chamado **0..N vezes por quadro, sempre com o MESMO dt** — a cena não assume 1 chamada por frame nem mede tempo por conta própria.
- Ordem do quadro: `window.update → onEnter → input → update* → render → onExit`.

**O loop** (`EngineManager::run()`):
- Relógio monotônico (`steady_clock`) + acumulador consumindo o tempo de quadro em passos de `fixedDt` constante; o resto fica para o próximo quadro.
- Teto anti-espiral (`maxFrameTime`): um quadro muito lento não gera passos suficientes para deixar o próximo ainda mais lento.
- `fixedDt` (default 1/60 s) e `maxFrameTime` (default 250 ms) configuráveis no construtor; valores não-positivos lançam `std::invalid_argument` na construção (um `fixedDt <= 0` travaria o loop interno).

**Testabilidade**: a fonte de tempo é **injetável** (`std::function<TimePoint()>`, default `steady_clock::now`) — nenhum teste dorme ou depende de tempo real.

## Testes (35/35 ✅, CI verde nos 3 jobs)

6 novos:
- **Quadro longo**: 35 ms com passo de 10 ms → exatamente 3 updates, todos com o mesmo dt.
- **Quadro curto**: 0 updates — e o render acontece mesmo assim.
- **Clamp**: quadro de 1 s com teto de 100 ms e passo de 50 ms → só 2 updates.
- **Construção inválida** lança `invalid_argument`.
- **Delegação**: `routing::GameManager::update` repassa o dt à cena atual.
- **Integração (call-log)**: o acumulador carrega o resto entre quadros — 25 ms/quadro com passo de 10 ms → 2 updates no quadro 1, 3 no quadro 2, na ordem `input → update* → render`.

Os fixtures existentes injetam relógio congelado (frameTime = 0), então os call-logs antigos continuam válidos e determinísticos.

## Fora do escopo (registrado na task)

- Interpolação de render (`render(alpha)`) — quando houver consumidor gráfico.
- Throttling/cap de FPS (sleep/vsync) — decisão da plataforma/janela.
- Física em si — módulo futuro (ADR 0001); este PR entrega só o contrato de tempo.

## Impacto no consumidor (8Puzzle)

Ao consumir a 0.3.0: cada cena ganha `void update(cengine::core::Seconds) override {}` — mudança mecânica. Oportunidade imediata: cronômetro de partida no `GameScene` via dt em vez de relógio ad-hoc.

## Docs

README ganhou a seção **"The frame and time"**; a nota de implementação do ADR 0001 sobre fixed timestep foi marcada como resolvida apontando para a task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
