### PR TITLE
feat(core): modo hospedado do loop — frame(dt) (task 15)

### DIFF
--- a/.ai/task/15-hosted-loop-mode.md
+++ b/.ai/task/15-hosted-loop-mode.md
@@ -1,7 +1,8 @@
 # 15 — Modo hospedado: dirigir o loop da engine de fora (`frame(dt)`)
 
-- **Status:** todo (desenho fechado em 2026-07-09 com o aprendizado da fase 1
-  da PoC The-Forge — pronto para executar)
+- **Status:** in-progress (2026-07-09 — engine pronta: `frame()` + `run()`
+  sobre ele + testes + docs; falta migrar o adaptador do 8Puzzle, após o
+  release)
 - **Prioridade:** 🟡 Média
 - **Categoria:** Arquitetura / core
 - **Depende de:** 14 (tempo no loop) ✅; PoC The-Forge fase 1 ✅ (8Puzzle,
@@ -142,12 +143,13 @@ questões abertas e revelou uma nova. Decisões:
 
 ## Critérios de aceite
 
-- [ ] `frame(dt)` público executando o quadro completo com o acumulador de
+- [x] `frame(dt)` público executando o quadro completo com o acumulador de
       fixed timestep interno (mesma garantia da task 14 nos dois modos).
-- [ ] `run()`/`start()` reimplementados sobre `frame()` sem mudança observável
-      (suíte de call-log intacta).
-- [ ] Testes do modo hospedado cobrindo os casos de timestep e a condição de
-      saída.
+- [x] `run()`/`start()` reimplementados sobre `frame()` sem mudança observável
+      (suíte de call-log intacta — 41/41 verdes, incluindo os antigos).
+- [x] Testes do modo hospedado (6 novos): fases em ordem, 0 updates com
+      render, acumulador persistindo ENTRE frames, clamp, retorno false na
+      saída, cleanup sem janela.
 - [ ] Adaptador The-Forge (8Puzzle) consumindo `frame()` — nenhuma lógica de
       fase/acumulador duplicada fora da engine.
 - [ ] Suíte verde (CI 3 jobs).

--- a/README.md
+++ b/README.md
@@ -149,6 +149,29 @@ with a monotonic clock and consumed in constant `dt` steps — `update` runs
 configurable in the `EngineManager` constructor). Put simulation (animations,
 timers, physics) in `update(dt)`; never measure time inside a scene.
 
+### Hosted mode (`frame(dt)`)
+
+Some platforms invert control: a framework owns the loop and calls *you* back
+each frame (The-Forge's `IApp::Update/Draw`, editors, browsers). For those
+hosts, skip `start()` and drive the engine with **`frame(dt)`** — it runs one
+complete frame (`onEnter` → `input` → `update(fixedDt)` 0..N times → `render`
+→ `onExit`) with the same internal fixed-timestep accumulator, and returns
+`false` when the game routed to the exit state:
+
+```cpp
+// window, pacing and input pump belong to the HOST — no IWindowManager here.
+core::EngineManager engine{nullptr, std::move(gameManager)};
+
+// inside the host's per-frame callback (dt measured by the host):
+if (!engine.frame(core::Seconds{dt})) {
+    // stop calling, shut the host down, and call engine.cleanup() on teardown
+}
+```
+
+`start()` is implemented on top of `frame()`, so the fixed-timestep guarantees
+are identical in both modes. If the host clamps its own `dt`, the engine's
+`maxFrameTime` clamp composes harmlessly on top.
+
 The public headers carry Doxygen comments describing each contract — start from
 [`IScene`](core/include/cengine/core/IScene.hpp) and
 [`IGameManager`](core/include/cengine/core/IGameManager.hpp).

--- a/core/include/cengine/core/EngineManager.hpp
+++ b/core/include/cengine/core/EngineManager.hpp
@@ -15,32 +15,53 @@ namespace cengine::core {
  *
  * É a única classe concreta do `core`. Recebe por injeção de dependência um
  * `IWindowManager` (a plataforma gráfica) e um `IGameManager` (as regras/telas
- * do jogo), assumindo posse de ambos, e roda o loop principal até o jogo pedir
- * para sair.
+ * do jogo), assumindo posse de ambos, e executa o quadro do jogo em um de dois
+ * modos:
  *
- * Cada iteração executa: `window.update()` → `game.onEnter()` → `game.input()`
- * → `game.update(dt)` (0..N vezes) → `game.render()` → `game.onExit()`, e para
- * quando `game.shouldExit()` retorna true — encerrando com `cleanup()`.
+ * - **Modo próprio**: `start()` bloqueia e dirige o loop até o jogo pedir
+ *   para sair (terminal, FTXUI — a engine é dona do loop).
+ * - **Modo hospedado**: um host com inversão de controle (The-Forge, editor,
+ *   browser) é dono do loop e chama `frame(dt)` uma vez por quadro. Nesse
+ *   modo NÃO há janela da engine (`windowManager == nullptr`): janela, pump
+ *   de mensagens e pacing são do host. Ver .ai/task/15.
+ *
+ * Cada quadro executa: `game.onEnter()` → `game.input()` → `game.update(dt)`
+ * (0..N vezes) → `game.render()` → `game.onExit()`. No modo próprio,
+ * `window.update()` precede o quadro e `shouldExit()` encerra o loop com
+ * `cleanup()`; no modo hospedado, `frame()` devolve false quando o jogo pediu
+ * saída e o host decide o shutdown (e chama `cleanup()` no teardown dele).
  *
  * ## Tempo (padrão "fix your timestep")
- * O tempo do quadro é medido com relógio monotônico e acumulado; a simulação
- * avança em passos FIXOS de `fixedDt` (default 1/60 s): num quadro curto,
- * `update` pode não rodar; num quadro longo, roda várias vezes — sempre com o
- * mesmo dt, o que mantém a simulação determinística e estável (pré-requisito
- * de física). O tempo de quadro é limitado a `maxFrameTime` (default 250 ms)
- * para evitar a espiral da morte (quadro lento → mais passos → quadro mais
- * lento). Render não interpola entre passos (fora do escopo — ver task 14).
+ * O tempo do quadro (medido pelo relógio no modo próprio; informado pelo host
+ * no modo hospedado) é acumulado; a simulação avança em passos FIXOS de
+ * `fixedDt` (default 1/60 s): num quadro curto, `update` pode não rodar — mas
+ * o `render` acontece mesmo assim; num quadro longo, roda várias vezes —
+ * sempre com o mesmo dt, o que mantém a simulação determinística e estável
+ * (pré-requisito de física). O tempo de quadro é limitado a `maxFrameTime`
+ * (default 250 ms) para evitar a espiral da morte (quadro lento → mais passos
+ * → quadro mais lento); se o host aplicar um clamp próprio antes, os dois se
+ * compõem sem conflito. Render não interpola entre passos (fora do escopo —
+ * ver task 14).
  *
  * A fonte de tempo é injetável (`clockNow`) para permitir testes
  * determinísticos do loop, sem tempo real; o default é o relógio monotônico
- * `std::chrono::steady_clock`.
+ * `std::chrono::steady_clock`. No modo hospedado ela não é consultada — o
+ * tempo vem por parâmetro.
  *
  * @code
+ * // modo próprio: a engine dirige
  * cengine::core::EngineManager engine{
  *     std::make_unique<MyWindowManager>(),
  *     std::make_unique<MyGameManager>()
  * };
  * engine.start(); // bloqueia até o jogo pedir para sair
+ *
+ * // modo hospedado: o host dirige (ex.: dentro do Draw() de um IApp)
+ * cengine::core::EngineManager hosted{nullptr, std::make_unique<MyGameManager>()};
+ * // ... por quadro do host:
+ * if (!hosted.frame(dtDoHost)) {
+ *     // o host encerra o loop dele e chama hosted.cleanup() no teardown
+ * }
  * @endcode
  */
 class EngineManager {
@@ -54,6 +75,8 @@ public:
 
     /**
      * @param windowManager plataforma gráfica (posse transferida à engine).
+     *                      Pode ser nullptr no modo hospedado — a janela é do
+     *                      host; nesse caso `start()` não deve ser usado.
      * @param gameManager   regras/telas do jogo (posse transferida à engine).
      * @param fixedDt       passo fixo da simulação (> 0; default 1/60 s).
      * @param maxFrameTime  teto do tempo de quadro acumulável (> 0; default
@@ -72,9 +95,29 @@ public:
     ~EngineManager() = default;
 
     /// Inicializa a janela e entra no game loop. Bloqueia até `shouldExit()`.
+    /// Modo próprio — requer `windowManager` (não use com nullptr).
     void start();
 
-    /// Libera recursos do jogo e da janela. Invocado ao final de `start()`.
+    /**
+     * Modo hospedado: executa UM quadro completo — `onEnter()` → `input()` →
+     * `update(fixedDt)` 0..N vezes (consumindo @p frameTime no acumulador
+     * interno, com o clamp de `maxFrameTime`) → `render()` → `onExit()`.
+     *
+     * O host (dono do loop) chama uma vez por quadro com o tempo decorrido
+     * que ele mesmo mediu; a janela NÃO é tocada (é do host). `start()` e
+     * `frame()` compartilham a mesma lógica de quadro — as garantias de
+     * fixed timestep valem nos dois modos.
+     *
+     * @param frameTime tempo decorrido desde o quadro anterior, medido pelo
+     *        host (será limitado a `maxFrameTime`).
+     * @return false quando o jogo pediu para sair (`shouldExit()`): o host
+     *         deve parar de chamar, encerrar o loop dele e invocar
+     *         `cleanup()` no teardown.
+     */
+    [[nodiscard]] bool frame(Seconds frameTime);
+
+    /// Libera recursos do jogo e da janela. Invocado ao final de `start()`;
+    /// no modo hospedado é responsabilidade do host, no teardown dele.
     void cleanup() const;
 
 private:
@@ -85,6 +128,7 @@ private:
     Seconds m_fixedDt;
     Seconds m_maxFrameTime;
     ClockNowFn m_clockNow;
+    Seconds m_accumulator{0}; // resto de tempo entre quadros (fixed timestep)
     bool m_isRunning;
 };
 

--- a/core/src/EngineManager.cpp
+++ b/core/src/EngineManager.cpp
@@ -42,36 +42,47 @@ void EngineManager::cleanup() const {
     }
 }
 
+bool EngineManager::frame(Seconds frameTime) {
+    // Teto anti-espiral: um quadro muito lento não pode gerar passos de
+    // simulação suficientes para deixar o próximo quadro ainda mais lento.
+    // (Se o host clampa o dt dele antes, os dois clamps se compõem.)
+    if (frameTime > m_maxFrameTime) {
+        frameTime = m_maxFrameTime;
+    }
+
+    m_gameManager->onEnter();
+    m_gameManager->input();
+
+    // Fixed timestep: consome o tempo acumulado em passos de dt constante
+    // (0..N chamadas por quadro; o resto fica para o próximo quadro).
+    for (m_accumulator += frameTime; m_accumulator >= m_fixedDt; m_accumulator -= m_fixedDt) {
+        m_gameManager->update(m_fixedDt);
+    }
+
+    // O render acontece mesmo num quadro sem passos de update.
+    m_gameManager->render();
+    m_gameManager->onExit();
+
+    return !m_gameManager->shouldExit();
+}
+
 void EngineManager::run() {
+    // O modo próprio é um consumidor de frame(): mede o tempo, atualiza a
+    // janela e delega o quadro — mesma lógica nos dois modos (ver task 15).
     TimePoint previous = m_clockNow();
-    Seconds accumulator{0};
 
     while (m_isRunning) {
         const TimePoint now = m_clockNow();
-        Seconds frameTime = now - previous;
+        const Seconds frameTime = now - previous;
         previous = now;
 
-        // Teto anti-espiral: um quadro muito lento não pode gerar passos de
-        // simulação suficientes para deixar o próximo quadro ainda mais lento.
-        if (frameTime > m_maxFrameTime) {
-            frameTime = m_maxFrameTime;
+        // A janela é da engine apenas no modo próprio; no hospedado ela é do
+        // host — por isso window.update() fica fora de frame().
+        if (m_windowManager) {
+            m_windowManager->update();
         }
 
-        m_windowManager->update();
-
-        m_gameManager->onEnter();
-        m_gameManager->input();
-
-        // Fixed timestep: consome o tempo acumulado em passos de dt constante
-        // (0..N chamadas por quadro; o resto fica para o próximo quadro).
-        for (accumulator += frameTime; accumulator >= m_fixedDt; accumulator -= m_fixedDt) {
-            m_gameManager->update(m_fixedDt);
-        }
-
-        m_gameManager->render();
-        m_gameManager->onExit();
-
-        m_isRunning = !m_gameManager->shouldExit();
+        m_isRunning = frame(frameTime);
     }
     cleanup();
 }

--- a/tests/core/EngineManagerTest.cpp
+++ b/tests/core/EngineManagerTest.cpp
@@ -162,6 +162,113 @@ TEST_F(EngineManagerFixedTimestepTest, FrameTimeIsClampedToMaxFrameTime) {
     m_engineManager->start();
 }
 
+// ------------------------------------------------------------------
+// Modo hospedado (task 15): o host é dono do loop e chama frame(dt);
+// sem IWindowManager (nullptr) — a janela é do host.
+// ------------------------------------------------------------------
+class EngineManagerHostedModeTest : public ::testing::Test {
+protected:
+    MockGameManager* m_gameManager{nullptr};
+    std::unique_ptr<EngineManager> m_engineManager;
+
+    void makeEngine(const Seconds fixedDt = EngineManager::kDefaultFixedDt,
+                    const Seconds maxFrameTime = EngineManager::kDefaultMaxFrameTime) {
+        auto gameManager = std::make_unique<MockGameManager>();
+        m_gameManager = gameManager.get();
+
+        // Sem window manager: contrato do modo hospedado. O relógio não é
+        // consultado em frame() — o tempo vem por parâmetro.
+        m_engineManager = std::make_unique<EngineManager>(
+            nullptr, std::move(gameManager), fixedDt, maxFrameTime);
+    }
+};
+
+// Um frame() executa a sequência completa de fases, na ordem do modo próprio.
+TEST_F(EngineManagerHostedModeTest, FrameRunsPhasesInOrder) {
+    makeEngine(Seconds{0.010});
+
+    testing::InSequence s;
+    EXPECT_CALL(*m_gameManager, onEnter()).Times(1);
+    EXPECT_CALL(*m_gameManager, input()).Times(1);
+    EXPECT_CALL(*m_gameManager, update(Seconds{0.010})).Times(1);
+    EXPECT_CALL(*m_gameManager, render()).Times(1);
+    EXPECT_CALL(*m_gameManager, onExit()).Times(1);
+    EXPECT_CALL(*m_gameManager, shouldExit()).WillOnce(testing::Return(false));
+
+    EXPECT_TRUE(m_engineManager->frame(Seconds{0.010}));
+}
+
+// Quadro mais curto que o passo fixo: nenhum update, mas o render acontece.
+TEST_F(EngineManagerHostedModeTest, ShortFrameRunsZeroUpdatesButRenders) {
+    makeEngine(Seconds{0.010});
+
+    EXPECT_CALL(*m_gameManager, onEnter()).Times(1);
+    EXPECT_CALL(*m_gameManager, input()).Times(1);
+    EXPECT_CALL(*m_gameManager, update(testing::_)).Times(0);
+    EXPECT_CALL(*m_gameManager, render()).Times(1);
+    EXPECT_CALL(*m_gameManager, onExit()).Times(1);
+    EXPECT_CALL(*m_gameManager, shouldExit()).WillOnce(testing::Return(false));
+
+    EXPECT_TRUE(m_engineManager->frame(Seconds{0.004}));
+}
+
+// Quadro longo: 35 ms com passo de 10 ms -> 3 updates com o MESMO dt; e o
+// RESTO (5 ms) persiste no acumulador ENTRE chamadas de frame() — um segundo
+// quadro de 5 ms completa o passo e gera 1 update.
+TEST_F(EngineManagerHostedModeTest, AccumulatorPersistsAcrossFrames) {
+    constexpr Seconds fixedDt{0.010};
+    makeEngine(fixedDt);
+
+    EXPECT_CALL(*m_gameManager, onEnter()).Times(2);
+    EXPECT_CALL(*m_gameManager, input()).Times(2);
+    EXPECT_CALL(*m_gameManager, render()).Times(2);
+    EXPECT_CALL(*m_gameManager, onExit()).Times(2);
+    EXPECT_CALL(*m_gameManager, shouldExit()).Times(2).WillRepeatedly(testing::Return(false));
+    EXPECT_CALL(*m_gameManager, update(fixedDt)).Times(4); // 3 no 1o quadro + 1 no 2o
+
+    EXPECT_TRUE(m_engineManager->frame(Seconds{0.035}));
+    EXPECT_TRUE(m_engineManager->frame(Seconds{0.005}));
+}
+
+// Teto anti-espiral vale também no modo hospedado: 1 s com teto de 100 ms e
+// passo de 50 ms -> apenas 2 updates.
+TEST_F(EngineManagerHostedModeTest, FrameTimeIsClampedToMaxFrameTime) {
+    constexpr Seconds fixedDt{0.050};
+    makeEngine(fixedDt, Seconds{0.100});
+
+    EXPECT_CALL(*m_gameManager, onEnter()).Times(1);
+    EXPECT_CALL(*m_gameManager, input()).Times(1);
+    EXPECT_CALL(*m_gameManager, render()).Times(1);
+    EXPECT_CALL(*m_gameManager, onExit()).Times(1);
+    EXPECT_CALL(*m_gameManager, shouldExit()).WillOnce(testing::Return(false));
+    EXPECT_CALL(*m_gameManager, update(fixedDt)).Times(2);
+
+    EXPECT_TRUE(m_engineManager->frame(Seconds{1.0}));
+}
+
+// frame() devolve false quando o jogo pediu para sair — o shutdown é do host.
+TEST_F(EngineManagerHostedModeTest, FrameReturnsFalseWhenGameRequestsExit) {
+    makeEngine();
+
+    EXPECT_CALL(*m_gameManager, onEnter()).Times(1);
+    EXPECT_CALL(*m_gameManager, input()).Times(1);
+    EXPECT_CALL(*m_gameManager, render()).Times(1);
+    EXPECT_CALL(*m_gameManager, onExit()).Times(1);
+    EXPECT_CALL(*m_gameManager, shouldExit()).WillOnce(testing::Return(true));
+
+    EXPECT_FALSE(m_engineManager->frame(Seconds{0.0}));
+}
+
+// cleanup() no modo hospedado (sem janela) libera só o jogo, sem desreferenciar
+// o window manager nulo.
+TEST_F(EngineManagerHostedModeTest, CleanupWithoutWindowManagerIsSafe) {
+    makeEngine();
+
+    EXPECT_CALL(*m_gameManager, cleanup()).Times(1);
+
+    m_engineManager->cleanup();
+}
+
 // Configuração inválida deve falhar na construção, não travar o loop.
 TEST(EngineManagerConstructionTest, RejectsNonPositiveFixedDt) {
     EXPECT_THROW(EngineManager(std::make_unique<MockWindowManager>(),


### PR DESCRIPTION
## O que muda

Implementa o **modo hospedado** do loop (`.ai/task/15-hosted-loop-mode.md`): hosts com inversão de controle (The-Forge, editores, browsers) são donos do loop e não podem usar `start()` — agora dirigem a engine com **`frame(dt)`**, que executa UM quadro completo (`onEnter → input → update(fixedDt) 0..N vezes → render → onExit`) com o acumulador de fixed timestep interno e devolve `false` quando o jogo pediu saída (o shutdown é decisão do host).

- `run()` vira consumidor de `frame()`: **mesma lógica de quadro nos dois modos** — a suíte de call-log existente não mudou.
- Acumulador sobe de variável local para membro (`m_accumulator`) — é isso que permite o resto de tempo persistir entre chamadas do host.
- Modo hospedado **não tem janela**: `windowManager == nullptr` passa a ser suportado (guarda no `run()`; `start()`/`cleanup()` já guardavam). `window.update()` fica fora de `frame()` de propósito — janela é do dono do loop.
- `cleanup()` no modo hospedado é responsabilidade do host (alinha com `Init/Exit` do IApp do The-Forge).
- Clamp de `maxFrameTime` compõe com o clamp próprio do host sem conflito (documentado).

## Por que assim

Desenho validado com host real — fase 1 da PoC The-Forge do 8Puzzle (adaptador manual chamando as fases). As decisões (API única em vez de split `simulate`/`present`, janela fora do quadro, ciclo de vida) estão registradas na seção "Decisões fechadas com a fase 1 da PoC" da task.

## Testes

- 6 novos (`EngineManagerHostedModeTest`): fases em ordem, quadro curto = 0 updates com render, **acumulador persistindo entre frames** (35ms→3 updates, +5ms→1 update), clamp anti-espiral, retorno `false` na saída, `cleanup()` sem janela.
- Suíte completa: **41/41 verdes**; call-log do modo próprio intacta.

## Fora deste PR

Migrar o adaptador do 8Puzzle (`8PuzzleForge`) para consumir `frame()` — último critério da task, feito após o release (candidato: 0.4.0, aditivo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
