### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to CEngine are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-09
+
+Hosted loop mode (task 15 of the [improvement plan](.ai/task/README.md)):
+frameworks with inversion of control (The-Forge's `IApp`, editors, browsers)
+own the loop and cannot call the blocking `start()` — they now drive the
+engine with `frame(dt)`, one call per frame, keeping every fixed-timestep
+guarantee from 0.3.0. Design validated against a real host (phase 1 of the
+8Puzzle The-Forge PoC).
+
+**Non-breaking release** — purely additive; no consumer changes required.
+
+### Added
+
+- **`EngineManager::frame(Seconds frameTime)`**: runs ONE complete frame
+  (`onEnter` → `input` → `update(fixedDt)` 0..N times → `render` → `onExit`)
+  consuming the host-measured `frameTime` in the internal fixed-timestep
+  accumulator (now a member — the remainder persists across calls). Returns
+  `false` when the game routed to the exit state; shutdown is the host's
+  decision, and the host calls `cleanup()` on its teardown.
+- **Hosted-mode tests** (6): phase order, short frame (0 updates, render still
+  runs), accumulator persisting across `frame()` calls, `maxFrameTime` clamp,
+  exit condition, `cleanup()` without a window manager.
+- **README section** on hosted mode with the per-frame callback recipe.
+
+### Changed
+
+- **`run()` is now a consumer of `frame()`** — both modes share the exact same
+  frame logic; the existing call-log suite passes unchanged.
+- **`windowManager == nullptr` is supported** (hosted mode has no engine
+  window: the host owns window, message pump and pacing). `run()` gained the
+  missing null guard; `frame()` never touches the window by design.
+- `maxFrameTime` clamping composes harmlessly with a host-side `dt` clamp
+  (documented); the injectable clock is not consulted in hosted mode.
+
 ## [0.3.0] - 2026-07-08
 
 Time in the loop (task 14 of the [improvement plan](.ai/task/README.md)): the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.23)
+﻿cmake_minimum_required(VERSION 3.23)
 
-project(cengine VERSION 0.3.0 LANGUAGES CXX)
+project(cengine VERSION 0.4.0 LANGUAGES CXX)
 
-# Define padrão do projeto
+# Define padrÃ£o do projeto
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -11,13 +11,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 enable_testing()
 
 # -------------------------------------------------------------
-# Opções de build (módulos opt-in — ver ADR 0001)
+# OpÃ§Ãµes de build (mÃ³dulos opt-in â€” ver ADR 0001)
 # -------------------------------------------------------------
 option(CENGINE_BUILD_ROUTING "Build the optional routing module (cengine::routing)" ON)
 option(CENGINE_BUILD_TESTS   "Build the test suite" ON)
 
 # -------------------------------------------------------------
-# Core (sempre) + módulos opcionais
+# Core (sempre) + mÃ³dulos opcionais
 # -------------------------------------------------------------
 add_subdirectory(core)
 


### PR DESCRIPTION
Release **0.4.0** — modo hospedado do loop (task 15): CHANGELOG + bump de versao no CMakeLists. Aditivo, sem breaking — nenhuma mudanca exigida dos consumidores. Suite 41/41 verde com a versao nova. Apos o merge: tag 0.4.0 no commit de merge e migracao do adaptador 8PuzzleForge para frame(dt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)