### PR TITLE
feat(core): IWindowManager::present() - fim do quadro na janela (task 16)

### DIFF
--- a/.ai/task/16-window-present-hook.md
+++ b/.ai/task/16-window-present-hook.md
@@ -1,7 +1,8 @@
 # 16 — Fim do quadro na janela: `IWindowManager::present()`
 
-- **Status:** todo (desenho esboçado em 2026-07-09; executar quando a fase 2
-  da PoC The-Forge — task 02 do 8Puzzle — chegar ao degrau 2)
+- **Status:** in-progress (implementação em 2026-07-10 —
+  `feature/16-window-present-hook`; falta release 0.5.0 + migração do
+  8Puzzle + validação no degrau 2)
 - **Prioridade:** 🟡 Média (sobe com a fase 2)
 - **Categoria:** Arquitetura / core
 - **Depende de:** 15 ✅ (modo hospedado). Consumidor real: 8Puzzle task 02
@@ -61,14 +62,17 @@ No `EngineManager`:
   commitada não desenha — o quadro apresentado é o da cena que rendeu).
   Confirmar na execução com os testes de call-log.
 
-## Questões a fechar na execução
+## Questões fechadas na execução (2026-07-10)
 
-1. `present()` deve rodar quando `shouldExit()` já retornou true no mesmo
-   quadro? (Provável: sim — o último quadro desenhado merece aparecer; mas
-   validar com o caso real do The-Forge.)
-2. Migração dos consumidores: terminal (`present()` vazio), FTXUI (mover o
-   `Screen.Print()` do draw das cenas para o window manager, ou manter vazio
-   numa primeira leva — decidir pelo menor diff).
+1. `present()` RODA quando `shouldExit()` retornou true no mesmo quadro —
+   o último quadro desenhado é apresentado antes do `cleanup()`. No run():
+   `update()` → `frame()` → `present()`, sem condicional no retorno.
+   Coberto por teste (call-log e InSequence). Revalidar com o caso real do
+   The-Forge no degrau 2.
+2. Migração dos consumidores pelo MENOR diff: terminal e FTXUI implementam
+   `present()` vazio numa primeira leva. Mover o `Screen.Print()` do FTXUI
+   para o window manager fica como melhoria opcional futura (o sinal de
+   desenho segue registrado no Problema).
 
 ## Passos
 

--- a/.ai/task/16-window-present-hook.md
+++ b/.ai/task/16-window-present-hook.md
@@ -73,6 +73,13 @@ No `EngineManager`:
    `present()` vazio numa primeira leva. Mover o `Screen.Print()` do FTXUI
    para o window manager fica como melhoria opcional futura (o sinal de
    desenho segue registrado no Problema).
+3. `present()` DEPOIS do `onExit()` (review do PR #18 questionou lifetime:
+   o commit da rota destrói a cena que rendeu antes do submit). Mantido:
+   cenas são lógica pura e nunca possuem recurso de GPU — tudo que o quadro
+   gravado referencia pertence à plataforma (ponte de desenho/window
+   manager); e o modo hospedado (fase 1, validado no 8PuzzleForge) já
+   apresenta depois de `frame()`/`onExit()` sem problema. O contrato ficou
+   explícito no @note do `present()`.
 
 ## Passos
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,21 @@ the loop.
 
 ### The frame and time
 
-Each frame runs `input()` → `update(dt)` → `draw()` on the active scene. The
-loop uses a **fixed timestep** ("fix your timestep"): frame time is measured
+Each frame runs `input()` → `update(dt)` → `draw()` on the active scene. In
+engine-owned mode the window's frame *wraps* the game phases, with a symmetric
+begin/end:
+
+```
+window.update()   // OS events, frame setup (acquire image, begin command buffer...)
+game phases       // onEnter -> input -> update(fixedDt) 0..N -> render -> onExit
+window.present()  // close & present the frame (end cmd, submit, queuePresent)
+```
+
+`present()` runs after every frame — including the last one, when the game has
+just routed to the exit state: what was drawn is presented before `cleanup()`.
+Platforms with no present concept (a plain terminal) implement it empty.
+
+The loop uses a **fixed timestep** ("fix your timestep"): frame time is measured
 with a monotonic clock and consumed in constant `dt` steps — `update` runs
 **0..N times per frame, always with the same `dt`** (default 1/60 s,
 configurable in the `EngineManager` constructor). Put simulation (animations,

--- a/core/include/cengine/core/EngineManager.hpp
+++ b/core/include/cengine/core/EngineManager.hpp
@@ -26,10 +26,13 @@ namespace cengine::core {
  *   de mensagens e pacing são do host. Ver .ai/task/15.
  *
  * Cada quadro executa: `game.onEnter()` → `game.input()` → `game.update(dt)`
- * (0..N vezes) → `game.render()` → `game.onExit()`. No modo próprio,
- * `window.update()` precede o quadro e `shouldExit()` encerra o loop com
- * `cleanup()`; no modo hospedado, `frame()` devolve false quando o jogo pediu
- * saída e o host decide o shutdown (e chama `cleanup()` no teardown dele).
+ * (0..N vezes) → `game.render()` → `game.onExit()`. No modo próprio o quadro
+ * da janela envolve as fases — `window.update()` antes (eventos de SO,
+ * preparo do quadro) e `window.present()` depois (fechar/apresentar o que foi
+ * desenhado, inclusive no último quadro) — e `shouldExit()` encerra o loop
+ * com `cleanup()`; no modo hospedado, `frame()` devolve false quando o jogo
+ * pediu saída e o host decide o shutdown (e chama `cleanup()` no teardown
+ * dele).
  *
  * ## Tempo (padrão "fix your timestep")
  * O tempo do quadro (medido pelo relógio no modo próprio; informado pelo host

--- a/core/include/cengine/core/IWindowManager.hpp
+++ b/core/include/cengine/core/IWindowManager.hpp
@@ -9,9 +9,16 @@ namespace cengine::core {
  * o jogo fornece uma implementação (SDL, Raylib, GLFW, terminal...) e a engine
  * só a aciona pelo contrato abaixo.
  *
- * Chamadas pelo `EngineManager`: `init()` uma vez em `start()`, `update()` toda
- * iteração do loop (processar eventos da janela, swap de buffers), e `cleanup()`
- * uma vez ao encerrar.
+ * Chamadas pelo `EngineManager` (modo próprio): `init()` uma vez em `start()`;
+ * a cada iteração do loop, `update()` ANTES das fases do jogo e `present()`
+ * DEPOIS delas; `cleanup()` uma vez ao encerrar. O quadro tem simetria
+ * início/fim:
+ *
+ * @code
+ * window.update()   // eventos de SO, preparo do quadro (acquire, beginCmd...)
+ * fases do jogo     // onEnter -> input -> update(fixedDt) 0..N -> render -> onExit
+ * window.present()  // fecha e apresenta o quadro (endCmd, submit, queuePresent)
+ * @endcode
  */
 class IWindowManager {
 public:
@@ -20,8 +27,17 @@ public:
     /// Cria/inicializa a janela e o contexto gráfico. Chamado uma vez.
     virtual void init() = 0;
 
-    /// Atualiza a janela por iteração (eventos de SO, apresentação do quadro).
+    /// Início do quadro: eventos de SO e preparo do desenho (em GPU: adquirir
+    /// a imagem do swapchain, abrir o command buffer). Chamado toda iteração,
+    /// antes das fases do jogo.
     virtual void update() = 0;
+
+    /// Fim do quadro: fecha e apresenta o que as fases desenharam (em GPU:
+    /// endCmd, submit, queuePresent; no terminal: imprimir a tela — ou vazio).
+    /// Chamado toda iteração, depois de `render()`/`onExit()` — inclusive no
+    /// último quadro, quando o jogo já pediu saída: o quadro desenhado é
+    /// apresentado antes do `cleanup()`.
+    virtual void present() = 0;
 
     /// Destrói a janela e libera recursos gráficos. Chamado uma vez, ao sair.
     virtual void cleanup() = 0;

--- a/core/include/cengine/core/IWindowManager.hpp
+++ b/core/include/cengine/core/IWindowManager.hpp
@@ -37,6 +37,14 @@ public:
     /// Chamado toda iteração, depois de `render()`/`onExit()` — inclusive no
     /// último quadro, quando o jogo já pediu saída: o quadro desenhado é
     /// apresentado antes do `cleanup()`.
+    ///
+    /// @note Roda DEPOIS do commit de troca de cena (`onExit()` pode destruir
+    ///       a cena que rendeu o quadro). Por isso o contrato exige que todo
+    ///       recurso referenciado pelo quadro gravado (fontes, buffers,
+    ///       swapchain...) pertença à plataforma — cenas são lógica pura e
+    ///       desenham via ponte da plataforma, nunca possuindo recurso de
+    ///       GPU. Mesma ordem do modo hospedado, em que o host apresenta
+    ///       depois de `frame()` retornar.
     virtual void present() = 0;
 
     /// Destrói a janela e libera recursos gráficos. Chamado uma vez, ao sair.

--- a/core/src/EngineManager.cpp
+++ b/core/src/EngineManager.cpp
@@ -77,12 +77,18 @@ void EngineManager::run() {
         previous = now;
 
         // A janela é da engine apenas no modo próprio; no hospedado ela é do
-        // host — por isso window.update() fica fora de frame().
+        // host — por isso update()/present() ficam fora de frame(). present()
+        // roda mesmo no último quadro (shouldExit): o que foi desenhado é
+        // apresentado antes do cleanup.
         if (m_windowManager) {
             m_windowManager->update();
         }
 
         m_isRunning = frame(frameTime);
+
+        if (m_windowManager) {
+            m_windowManager->present();
+        }
     }
     cleanup();
 }

--- a/tests/core/EngineManagerTest.cpp
+++ b/tests/core/EngineManagerTest.cpp
@@ -69,7 +69,11 @@ TEST_F(EngineManagerTest, Start_InitializesWindowAndRunsLoop) {
     // 3. shouldExit() é chamado para verificar se o loop deve continuar.
     EXPECT_CALL(*m_capturedGameManager, shouldExit()).WillOnce(testing::Return(true));
 
-    // 4. O loop termina e o método cleanup() é chamado.
+    // 4. present() fecha o quadro DEPOIS das fases — inclusive neste último
+    //    quadro, em que o jogo já pediu saída.
+    EXPECT_CALL(*m_capturedWindowManager, present()).Times(1);
+
+    // 5. O loop termina e o método cleanup() é chamado.
     EXPECT_CALL(*m_capturedGameManager, cleanup()).Times(1);
     EXPECT_CALL(*m_capturedWindowManager, cleanup()).Times(1);
 
@@ -120,6 +124,7 @@ protected:
         // Fora do foco destes testes: um quadro só, sem InSequence.
         EXPECT_CALL(*m_windowManager, init()).Times(1);
         EXPECT_CALL(*m_windowManager, update()).Times(1);
+        EXPECT_CALL(*m_windowManager, present()).Times(1);
         EXPECT_CALL(*m_windowManager, cleanup()).Times(1);
         EXPECT_CALL(*m_gameManager, onEnter()).Times(1);
         EXPECT_CALL(*m_gameManager, input()).Times(1);

--- a/tests/core/integration/EngineManagerIntegrationTest.cpp
+++ b/tests/core/integration/EngineManagerIntegrationTest.cpp
@@ -52,10 +52,12 @@ TEST_F(EngineManagerIntegrationTest, Start_ExecutesFullLifecycle) {
     m_engineManager->start();
 
     // Verificamos o log de chamadas para garantir que a sequência foi a correta.
-    ASSERT_EQ(m_rawWindowManager->callLog.size(), 3);
+    // present() fecha o quadro depois das fases — mesmo no último (saída).
+    ASSERT_EQ(m_rawWindowManager->callLog.size(), 4);
     ASSERT_EQ(m_rawWindowManager->callLog[0], "init");
     ASSERT_EQ(m_rawWindowManager->callLog[1], "update");
-    ASSERT_EQ(m_rawWindowManager->callLog[2], "cleanup");
+    ASSERT_EQ(m_rawWindowManager->callLog[2], "present");
+    ASSERT_EQ(m_rawWindowManager->callLog[3], "cleanup");
 
     ASSERT_EQ(m_rawGameManager->callLog.size(), 5);
     ASSERT_EQ(m_rawGameManager->callLog[0], "onEnter");
@@ -75,12 +77,15 @@ TEST_F(EngineManagerIntegrationTest, Start_ExecutesLoopCorrectlyForMultipleItera
     // Executa o método start() do EngineManager, que contém o loop de execução.
     m_engineManager->start();
 
-    // O log do WindowManager terá 'init' uma vez e 'update' duas vezes.
-    ASSERT_EQ(m_rawWindowManager->callLog.size(), 4);
+    // O log do WindowManager terá 'init' uma vez e o par update/present por
+    // quadro (o quadro da janela envolve as fases do jogo).
+    ASSERT_EQ(m_rawWindowManager->callLog.size(), 6);
     ASSERT_EQ(m_rawWindowManager->callLog[0], "init");
     ASSERT_EQ(m_rawWindowManager->callLog[1], "update");
-    ASSERT_EQ(m_rawWindowManager->callLog[2], "update");
-    ASSERT_EQ(m_rawWindowManager->callLog[3], "cleanup");
+    ASSERT_EQ(m_rawWindowManager->callLog[2], "present");
+    ASSERT_EQ(m_rawWindowManager->callLog[3], "update");
+    ASSERT_EQ(m_rawWindowManager->callLog[4], "present");
+    ASSERT_EQ(m_rawWindowManager->callLog[5], "cleanup");
 
     // O log do GameManager terá o ciclo completo de onEnter, input, render, onExit duas vezes,
     // e o cleanup no final.

--- a/tests/core/integration/FakeImplementations.hpp
+++ b/tests/core/integration/FakeImplementations.hpp
@@ -24,6 +24,10 @@ public:
         callLog.push_back("update");
     }
 
+    void present() override {
+        callLog.push_back("present");
+    }
+
     void cleanup() override {
         callLog.push_back("cleanup");
     }

--- a/tests/mock/MockWindowManager.hpp
+++ b/tests/mock/MockWindowManager.hpp
@@ -8,5 +8,6 @@ class MockWindowManager : public cengine::core::IWindowManager {
 public:
     MOCK_METHOD(void, init, (), (override));
     MOCK_METHOD(void, update, (), (override));
+    MOCK_METHOD(void, present, (), (override));
     MOCK_METHOD(void, cleanup, (), (override));
 };


### PR DESCRIPTION
## O que muda

`IWindowManager` ganha o quarto método: **`present()`**, chamado pelo `EngineManager::run()` ao FIM de cada iteração, depois das fases do jogo. O quadro do modo próprio fica simétrico:

```
window.update()   -> eventos de SO, preparo do quadro (acquire, beginCmd...)
fases do jogo     -> onEnter -> input -> update(fixedDt) 0..N -> render -> onExit
window.present()  -> fecha e apresenta o quadro (endCmd, submit, queuePresent)
```

## Por quê

No modo biblioteca do The-Forge (8puzzle task 02, degrau 2) a cengine é dona do loop e alguém precisa fechar o quadro de GPU DEPOIS do `render()` — esse gancho não existia (task 16).

## Decisões

- **`present()` roda mesmo no último quadro** (quando `shouldExit()` já retornou true): o quadro desenhado é apresentado antes do `cleanup()`. Sem condicional no `run()`.
- **Modo hospedado intocado**: `frame(dt)` continua sem tocar a janela — contrato da task 15 preservado.
- **Consumidores migram pelo menor diff**: terminal e FTXUI implementam `present()` vazio na primeira leva.

## Breaking

Pequeno — método puro novo em interface: toda implementação de `IWindowManager` precisa adicionar `present()`. Âncora do bump **0.5.0** (release PR na sequência).

## Testes

- Mock e fake ganharam `present()`; ordem `update -> fases -> present` coberta por `InSequence` (unit) e call-log (integração, incluindo o par update/present por quadro em loop de 2 iterações).
- Suíte completa: **41/41 verdes** (GCC MSYS2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
